### PR TITLE
Fix AdminClient.listServers docs/annotations.

### DIFF
--- a/docs/AdminClient.html
+++ b/docs/AdminClient.html
@@ -1737,7 +1737,7 @@ this method returns the first 100 signatures in your account.</p>
             <td class="type">
             
                 
-<span class="param-type">number</span>
+<span class="param-type">object</span>
 
 
             

--- a/lib/postmark/AdminClient.js
+++ b/lib/postmark/AdminClient.js
@@ -211,7 +211,7 @@ AdminClient.prototype.deleteServer = function(id, callback) {
  *
  * @memberOf AdminClient.prototype
  * @method listServers
- * @param {number} [query] An optional filter to use when retrieving the list of Servers.
+ * @param {object} [query] An optional filter to use when retrieving the list of Servers.
  * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
  */
 AdminClient.prototype.listServers = function(query, callback) {


### PR DESCRIPTION
listServers takes a query that is an object and I've updated the documentation and param annotations to reflect that.