### PR TITLE
Fix callback param name

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -117,7 +117,7 @@ client.sendEmail({
       &quot;Name&quot;: &quot;PrettyUnicorn.jpg&quot;,
       &quot;ContentType&quot;: &quot;image/jpeg&quot;
     }]
-}, function(error, success) {
+}, function(error, result) {
     if(error) {
         console.error(&quot;Unable to send via postmark: &quot; + error.message);
         return;


### PR DESCRIPTION
A few lines up the docs say callbacks receive `(error, result)`. Just for consistency.

EDIT: I see you also have a `gh-pages` branch, hopefully they're integrated, but let me know if this should be on the other branch.