### PR TITLE
Add support for module use behind proxy

### DIFF
--- a/lib/postmark/clientDefaults.js
+++ b/lib/postmark/clientDefaults.js
@@ -1,6 +1,7 @@
 var rev = require('git-rev');
 var sha = 'unknown revision';
 var version = require('../../package.json').version;
+var request = require('request');
 
 rev.long(function(longSha) {
   sha = longSha || 'unknown revision';
@@ -16,87 +17,91 @@ rev.long(function(longSha) {
  * @property {function} [requestFactory] Given the set of options, produce a new function that will be responsible for creating and processing HTTP requests.
  */
 var ClientDefaults = {
-
   requestHost: "api.postmarkapp.com",
   ssl: true,
-  requestFactory: function(options) {
-    var client = require('http' + (options.ssl === true ? 's' : ''));
 
-    return function(path, type, content, callback) {
-      var msg = null;
-      if (content) {
-        msg = JSON.stringify(content);
+  /**
+   * Returns function used to make HTTP requests based on the provided options
+   *
+   * @param {object} options
+   * @param {string} options.apiKey
+   * @param {string} options.authorizationHeader
+   * @param {string} options.requestHost
+   * @param {boolean} [options.ssl=true]  determines if requests are made using HTTP or HTTPS
+   * @returns {Function}
+   */
+  requestFactory: function(options) {
+    const protocol = options.ssl === true ? "https" : "http";
+    const baseUrl = protocol + "://" + options.requestHost;
+    var headers = {
+      "Accept"       : "application/json",
+      "Content-Type" : "application/json",
+      "User-Agent"   : "postmark.js (Package-version: " + version + ";Revision:" + sha + ")"
+    };
+    headers[options.authorizationHeader] = options.apiKey;
+    const proxyOptions = ["proxy", "strictSSL", "tunnel", "proxyHeaderWhiteList", "proxyHeaderExclusiveList"];
+
+    return makeRequest;
+
+    /**
+     * Make HTTP request
+     * @param {string} path         request uri
+     * @param {string} method       request method
+     * @param {object} content      request body
+     * @param {function} callback
+     */
+    function makeRequest(path, method, content, callback) {
+      if (typeof callback !== "function") {
+        callback = function(){ };
       }
 
-      var headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-        "User-Agent": "postmark.js (Package-version: " + version + ";Revision:" + sha + ")"
+      var reqData = {
+        headers : headers,
+        method  : method,
+        baseUrl : baseUrl,
+        uri     : path,
       };
 
-      headers[options.authorizationHeader] = options.apiKey;
-
-      if (msg) {
-        headers["Content-Length"] = Buffer.byteLength(msg);
+      for (var i=0; i<proxyOptions.length; i++) {
+        if (typeof options[i] !== "undefined") {
+          reqData[i] = options[i];
+        }
       }
 
-      var req = client.request({
-        host: options.requestHost,
-        path: path,
-        method: type,
-        headers: headers,
-        port: (options.ssl ? 443 : 80)
-      }, function(response) {
+      if (content) {
+        reqData.body = JSON.stringify(content);
+        reqData.headers["Content-Length"] = Buffer.byteLength(reqData.body);
+      }
 
-        var body = "";
+      request(reqData, function(err, response, body) {
+        if (err) return callback(err);
 
-        response.on("data", function(i) {
-          body += i;
-        });
-
-        response.on("end", function() {
-          if (response.statusCode == 200) {
-            if (callback) {
-              try {
-                var ret = JSON.parse(body);
-                callback(null, ret);
-              } catch (e) {
-                callback(e);
-              }
-            }
-          } else {
-            if (callback) {
-              var data;
-              try {
-                data = JSON.parse(body);
-                callback({
-                  status: response.statusCode,
-                  message: data['Message'],
-                  code: data['ErrorCode']
-                });
-              } catch (e) {
-                callback({
-                  status: 404,
-                  message: "Unsupported Request Method and Protocol",
-                  code: -1 // this is a fake error code !
-                });
-              }
-
-            }
+        if (response.statusCode == 200) {
+          try {
+            var ret = JSON.parse(body);
+            return callback(null, ret);
+          } catch (e) {
+            return callback(e);
           }
-        });
-      });
+        }
 
-      req.on('error', function(err) {
-        if (callback) {
-          callback(err);
+        // there was an error somewhere
+        var data;
+        try {
+          data = JSON.parse(body);
+          return callback({
+            status: response.statusCode,
+            message: data['Message'],
+            code: data['ErrorCode']
+          });
+        } catch (e) {
+          return callback({
+            status: 404,
+            message: "Unsupported Request Method and Protocol",
+            code: -1 // this is a fake error code !
+          });
         }
       });
-
-      if (msg) {
-        req.write(msg);
-      }
-      req.end();
     }
   }
 };

--- a/lib/postmark/clientDefaults.js
+++ b/lib/postmark/clientDefaults.js
@@ -12,9 +12,9 @@ rev.long(function(longSha) {
  * You can pass options in client constructors to override these options.
  *
  * @typedef ClientDefaults
- * @property {string} [requestHost=api.postmarkapp.com] The host name for whichever server we should use to access the Postmark API.
- * @property {boolean} [ssl=true] Should ssl be used for accessing the API (http/https)?
- * @property {function} [requestFactory] Given the set of options, produce a new function that will be responsible for creating and processing HTTP requests.
+ * @property {string}   [requestHost=api.postmarkapp.com] The host name for whichever server we should use to access the Postmark API.
+ * @property {boolean}  [ssl=true]                        Should ssl be used for accessing the API (http/https)?
+ * @property {function} [requestFactory]                  Given the set of options, produce a new function that will be responsible for creating and processing HTTP requests.
  */
 var ClientDefaults = {
   requestHost: "api.postmarkapp.com",
@@ -23,11 +23,16 @@ var ClientDefaults = {
   /**
    * Returns function used to make HTTP requests based on the provided options
    *
-   * @param {object} options
-   * @param {string} options.apiKey
-   * @param {string} options.authorizationHeader
-   * @param {string} options.requestHost
-   * @param {boolean} [options.ssl=true]  determines if requests are made using HTTP or HTTPS
+   * @param {object}   options
+   * @param {string}   options.apiKey
+   * @param {string}   options.authorizationHeader
+   * @param {string}   options.requestHost
+   * @param {boolean}  [options.ssl=true]           determines if requests are made using HTTP or HTTPS
+   * @param {string}   [options.proxy]              optional proxy url, reference https://github.com/request/request#proxies
+   * @param {boolean}  [options.strictSSL]
+   * @param {boolean}  [options.tunnel]
+   * @param {[string]} [options.proxyHeaderWhiteList]
+   * @param {[string]} [options.proxyHeaderExclusiveList]
    * @returns {Function}
    */
   requestFactory: function(options) {
@@ -63,8 +68,9 @@ var ClientDefaults = {
       };
 
       for (var i=0; i<proxyOptions.length; i++) {
-        if (typeof options[i] !== "undefined") {
-          reqData[i] = options[i];
+        var key = proxyOptions[i];
+        if (typeof options[key] !== "undefined") {
+          reqData[key] = options[key];
         }
       }
 

--- a/package.json
+++ b/package.json
@@ -1,69 +1,70 @@
 {
-    "name": "postmark",
-    "description": "Ridiculously Simple Email Sending From Node.js For http://www.postmarkapp.com",
-    "tags": [
-        "email",
-        "utility",
-        "postmark"
-    ],
-    "version": "1.3.1",
-    "author": "Chris Williams <voodootikigod@gmail.com>",
-    "contributors": [
-        "Aaron Blum",
-        "Aleksey Aleksandrov",
-        "Alex Shepard",
-        "Andrew Theken",
-        "Antony Jones",
-        "Ben Burwell",
-        "Ben Williamson",
-        "Chris Williams",
-        "Jakub Borys",
-        "Mark Nguyen",
-        "Matt",
-        "Matthew Blackshaw",
-        "Matthew Conlen",
-        "Ryan Kirkman",
-        "Scott Anderson",
-        "Sebastien Chopin",
-        "Theophane RUPIN",
-        "codesplicer",
-        "francescoRubini"
-    ],
-    "main": "./lib/postmark",
-    "directories": {
-        "lib": "./lib/postmark"
-    },
-    "scripts": {
-        "test": "node_modules/.bin/mocha tests/fixture_*.js",
-        "watchtests": "node_modules/.bin/mocha -R list -w --recursive -G tests/fixture_*.js",
-        "compile-docs": "echo 'Generating docs...' && mkdir -p ./docs && rm -r ./docs && node_modules/.bin/jsdoc -u ./tutorials -R README.md -c jsdoc.conf.json -t ./node_modules/ink-docstrap/template -d docs ./lib/postmark/*.js && cp ./tutorials/postmark-logo.png ./docs && git add -A ./docs && echo 'Generated docs!'",
-        "pull-docs": "git subtree pull --prefix docs origin gh-pages",
-        "push-docs": "git subtree push --prefix docs origin gh-pages"
-    },
-    "homepage": "http://wildbit.github.io/postmark.js",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/wildbit/postmark.js.git"
-    },
-    "bugs": {
-        "url": "https://github.com/wildbit/postmark.js/issues"
-    },
-    "engines": [
-        "node >=0.8.0"
-    ],
-    "precommit": [
-        "compile-docs",
-        "test"
-    ],
-    "devDependencies": {
-        "ink-docstrap": "git://github.com/wildbit/docstrap",
-        "jsdoc": "3.3.0-beta1",
-        "mocha": "2.1.0",
-        "nconf": "0.7.1",
-        "pre-commit": "1.0.2"
-    },
-    "dependencies": {
-        "git-rev": "0.2.1",
-        "merge": "1.2.0"
-    }
+  "name": "postmark",
+  "description": "Ridiculously Simple Email Sending From Node.js For http://www.postmarkapp.com",
+  "tags": [
+    "email",
+    "utility",
+    "postmark"
+  ],
+  "version": "1.3.1",
+  "author": "Chris Williams <voodootikigod@gmail.com>",
+  "contributors": [
+    "Aaron Blum",
+    "Aleksey Aleksandrov",
+    "Alex Shepard",
+    "Andrew Theken",
+    "Antony Jones",
+    "Ben Burwell",
+    "Ben Williamson",
+    "Chris Williams",
+    "Jakub Borys",
+    "Mark Nguyen",
+    "Matt",
+    "Matthew Blackshaw",
+    "Matthew Conlen",
+    "Ryan Kirkman",
+    "Scott Anderson",
+    "Sebastien Chopin",
+    "Theophane RUPIN",
+    "codesplicer",
+    "francescoRubini"
+  ],
+  "main": "./lib/postmark",
+  "directories": {
+    "lib": "./lib/postmark"
+  },
+  "scripts": {
+    "test": "node_modules/.bin/mocha tests/fixture_*.js",
+    "watchtests": "node_modules/.bin/mocha -R list -w --recursive -G tests/fixture_*.js",
+    "compile-docs": "echo 'Generating docs...' && mkdir -p ./docs && rm -r ./docs && node_modules/.bin/jsdoc -u ./tutorials -R README.md -c jsdoc.conf.json -t ./node_modules/ink-docstrap/template -d docs ./lib/postmark/*.js && cp ./tutorials/postmark-logo.png ./docs && git add -A ./docs && echo 'Generated docs!'",
+    "pull-docs": "git subtree pull --prefix docs origin gh-pages",
+    "push-docs": "git subtree push --prefix docs origin gh-pages"
+  },
+  "homepage": "http://wildbit.github.io/postmark.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wildbit/postmark.js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/wildbit/postmark.js/issues"
+  },
+  "engines": [
+    "node >=0.8.0"
+  ],
+  "precommit": [
+    "compile-docs",
+    "test"
+  ],
+  "devDependencies": {
+    "ink-docstrap": "git://github.com/wildbit/docstrap",
+    "jsdoc": "3.3.0-beta1",
+    "mocha": "2.1.0",
+    "nconf": "0.7.1",
+    "pre-commit": "1.0.2"
+  },
+  "dependencies": {
+    "git-rev": "0.2.1",
+    "merge": "1.2.0",
+    "request": "~2.78.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,70 +1,71 @@
 {
-  "name": "postmark",
-  "description": "Ridiculously Simple Email Sending From Node.js For http://www.postmarkapp.com",
-  "tags": [
-    "email",
-    "utility",
-    "postmark"
-  ],
-  "version": "1.3.1",
-  "author": "Chris Williams <voodootikigod@gmail.com>",
-  "contributors": [
-    "Aaron Blum",
-    "Aleksey Aleksandrov",
-    "Alex Shepard",
-    "Andrew Theken",
-    "Antony Jones",
-    "Ben Burwell",
-    "Ben Williamson",
-    "Chris Williams",
-    "Jakub Borys",
-    "Mark Nguyen",
-    "Matt",
-    "Matthew Blackshaw",
-    "Matthew Conlen",
-    "Ryan Kirkman",
-    "Scott Anderson",
-    "Sebastien Chopin",
-    "Theophane RUPIN",
-    "codesplicer",
-    "francescoRubini"
-  ],
-  "main": "./lib/postmark",
-  "directories": {
-    "lib": "./lib/postmark"
-  },
-  "scripts": {
-    "test": "node_modules/.bin/mocha tests/fixture_*.js",
-    "watchtests": "node_modules/.bin/mocha -R list -w --recursive -G tests/fixture_*.js",
-    "compile-docs": "echo 'Generating docs...' && mkdir -p ./docs && rm -r ./docs && node_modules/.bin/jsdoc -u ./tutorials -R README.md -c jsdoc.conf.json -t ./node_modules/ink-docstrap/template -d docs ./lib/postmark/*.js && cp ./tutorials/postmark-logo.png ./docs && git add -A ./docs && echo 'Generated docs!'",
-    "pull-docs": "git subtree pull --prefix docs origin gh-pages",
-    "push-docs": "git subtree push --prefix docs origin gh-pages"
-  },
-  "homepage": "http://wildbit.github.io/postmark.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/wildbit/postmark.js.git"
-  },
-  "bugs": {
-    "url": "https://github.com/wildbit/postmark.js/issues"
-  },
-  "engines": [
-    "node >=0.8.0"
-  ],
-  "precommit": [
-    "compile-docs",
-    "test"
-  ],
-  "devDependencies": {
-    "ink-docstrap": "git://github.com/wildbit/docstrap",
-    "jsdoc": "3.3.0-beta1",
-    "mocha": "2.1.0",
-    "nconf": "0.7.1",
-    "pre-commit": "1.0.2"
-  },
-  "dependencies": {
-    "git-rev": "0.2.1",
-    "merge": "1.2.0",
-    "request": "~2.78.0"
-  }
+    "name": "postmark",
+    "description": "Ridiculously Simple Email Sending From Node.js For http://www.postmarkapp.com",
+    "tags": [
+        "email",
+        "utility",
+        "postmark"
+    ],
+    "version": "1.3.1",
+    "author": "Chris Williams <voodootikigod@gmail.com>",
+    "contributors": [
+        "Aaron Blum",
+        "Aleksey Aleksandrov",
+        "Alex Shepard",
+        "Andrew Theken",
+        "Antony Jones",
+        "Ben Burwell",
+        "Ben Williamson",
+        "Chris Williams",
+        "Jakub Borys",
+        "Mark Nguyen",
+        "Matt",
+        "Matthew Blackshaw",
+        "Matthew Conlen",
+        "Ryan Kirkman",
+        "Scott Anderson",
+        "Sebastien Chopin",
+        "Theophane RUPIN",
+        "codesplicer",
+        "francescoRubini",
+        "resteinbock"
+    ],
+    "main": "./lib/postmark",
+    "directories": {
+        "lib": "./lib/postmark"
+    },
+    "scripts": {
+        "test": "node_modules/.bin/mocha tests/fixture_*.js",
+        "watchtests": "node_modules/.bin/mocha -R list -w --recursive -G tests/fixture_*.js",
+        "compile-docs": "echo 'Generating docs...' && mkdir -p ./docs && rm -r ./docs && node_modules/.bin/jsdoc -u ./tutorials -R README.md -c jsdoc.conf.json -t ./node_modules/ink-docstrap/template -d docs ./lib/postmark/*.js && cp ./tutorials/postmark-logo.png ./docs && git add -A ./docs && echo 'Generated docs!'",
+        "pull-docs": "git subtree pull --prefix docs origin gh-pages",
+        "push-docs": "git subtree push --prefix docs origin gh-pages"
+    },
+    "homepage": "http://wildbit.github.io/postmark.js",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/wildbit/postmark.js.git"
+    },
+    "bugs": {
+        "url": "https://github.com/wildbit/postmark.js/issues"
+    },
+    "engines": [
+        "node >=0.8.0"
+    ],
+    "precommit": [
+        "compile-docs",
+        "test"
+    ],
+    "devDependencies": {
+        "ink-docstrap": "git://github.com/wildbit/docstrap",
+        "jsdoc": "3.3.0-beta1",
+        "mocha": "2.1.0",
+        "nconf": "0.7.1",
+        "pre-commit": "1.0.2"
+    },
+    "dependencies": {
+        "git-rev": "0.2.1",
+        "merge": "1.2.0",
+        "request": "~2.78.0"
+    }
 }


### PR DESCRIPTION
Use [request](https://github.com/request/request) library instead of Node's [http](https://nodejs.org/api/https.html) and [http](https://nodejs.org/api/http.html) libraries to add support for making API calls on servers behind proxies.

Usage:
Set environment variables for proxy urls as defined [here](https://github.com/request/request#proxies) or provide proxy configuration when instantiating Postmark Client in the `options` object.