### PR TITLE
removes dependency to git-rev

### DIFF
--- a/lib/postmark/clientDefaults.js
+++ b/lib/postmark/clientDefaults.js
@@ -1,10 +1,10 @@
-var rev = require('git-rev');
 var sha = 'unknown revision';
 var version = require('../../package.json').version;
+var exec = require('child_process').exec
 
-rev.long(function(longSha) {
-  sha = longSha || 'unknown revision';
-});
+exec('git rev-parse HEAD', { cwd: __dirname }, function (err, stdout, stderr) {
+  sha = stdout.split('\n').join('') || 'unknown revision'
+})
 
 /**
  * The defaults used for the construction of new clients.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "utility",
         "postmark"
     ],
-    "version": "1.3.1",
+    "version": "1.3.2",
     "author": "Chris Williams <voodootikigod@gmail.com>",
     "contributors": [
         "Aaron Blum",
@@ -63,7 +63,6 @@
         "pre-commit": "1.0.2"
     },
     "dependencies": {
-        "git-rev": "0.2.1",
         "merge": "1.2.0"
     }
 }

--- a/testing_keys.json.example
+++ b/testing_keys.json.example
@@ -6,9 +6,9 @@
 	"WRITE_ACCOUNT_TOKEN" : "<token>",
 	"WRITE_TEST_SERVER_TOKEN" : "<token>",
 	"WRITE_TEST_SENDER_EMAIL_ADDRESS" : "apps@example.com",
-	"WRITE_TEST_SENDER_SIGNATURE_PROTOTYPE": "anything+[TOKEN]@exmaple.com",
+	"WRITE_TEST_SENDER_SIGNATURE_PROTOTYPE": "anything+[TOKEN]@example.com",
 	"WRITE_TEST_EMAIL_RECIPIENT_ADDRESS" : "andrew+testing@example.com",
 	"WRITE_TEST_DOMAIN_NAME" : "domain-verification.pstmrk.it",
-	
+
 	"BASE_URL" : "https://api.postmarkapp.com"
 }


### PR DESCRIPTION
Hey everyone !

This commit removes a dependency, making the library a bit easier to audit/inspect.

I don't know if you still aim to support node `0.8.0`, so I have not gone ahead and removed the `merge` dependency. But on `node >= 4.0.0`, `Object.assign` is supported and could replace `merge`. Let me know if you need a hand removing that dependency, I'm happy to help.

I've bumped the minor version up. I don't know if this is what you'd want though, since dependents on `postmark` might have been using `git-rev` without explicitly installing it. So this PR is theoretically a breaking change.

Best regards, Conrad