### PR TITLE
WIP: Add promise support

### DIFF
--- a/lib/postmark/AdminClient.js
+++ b/lib/postmark/AdminClient.js
@@ -49,7 +49,7 @@ AdminClient.prototype.processRequestWithoutBody = function(path, type, query, ca
   if (query) {
     path += '?' + querystring.stringify(query);
   }
-  this.processRequestWithBody(path, type, null, callback);
+  return this.processRequestWithBody(path, type, null, callback);
 }
 
 /**
@@ -67,7 +67,7 @@ AdminClient.prototype.listSenderSignatures = function(query, callback) {
     count: 100,
     offset: 0
   }, query);
-  this.processRequestWithoutBody('/senders', 'GET', query, callback);
+  return this.processRequestWithoutBody('/senders', 'GET', query, callback);
 };
 
 /**
@@ -79,7 +79,7 @@ AdminClient.prototype.listSenderSignatures = function(query, callback) {
  * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
  */
 AdminClient.prototype.getSenderSignature = function(id, callback) {
-  this.processRequestWithoutBody('/senders/' + id, 'GET', null, callback);
+  return this.processRequestWithoutBody('/senders/' + id, 'GET', null, callback);
 };
 
 /**
@@ -91,7 +91,7 @@ AdminClient.prototype.getSenderSignature = function(id, callback) {
  * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
  */
 AdminClient.prototype.createSenderSignature = function(options, callback) {
-  this.processRequestWithBody('/senders/', 'POST', options, callback);
+  return this.processRequestWithBody('/senders/', 'POST', options, callback);
 };
 
 /**
@@ -104,7 +104,7 @@ AdminClient.prototype.createSenderSignature = function(options, callback) {
  * @param {postmarkCallback} callback A standard callback that is called when the API request completes.
  */
 AdminClient.prototype.editSenderSignature = function(id, options, callback) {
-  this.processRequestWithBody('/senders/' + id, 'PUT', options, callback);
+  return this.processRequestWithBody('/senders/' + id, 'PUT', options, callback);
 };
 
 /**
@@ -116,7 +116,7 @@ AdminClient.prototype.editSenderSignature = function(id, options, callback) {
  * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
  */
 AdminClient.prototype.deleteSenderSignature = function(id, callback) {
-  this.processRequestWithoutBody('/senders/' + id, 'DELETE', null, callback);
+  return this.processRequestWithoutBody('/senders/' + id, 'DELETE', null, callback);
 };
 
 /**
@@ -128,7 +128,7 @@ AdminClient.prototype.deleteSenderSignature = function(id, callback) {
  * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
  */
 AdminClient.prototype.resendSenderSignatureConfirmation = function(id, callback) {
-  this.processRequestWithBody('/senders/' + id + '/resend', 'POST', null, callback);
+  return this.processRequestWithBody('/senders/' + id + '/resend', 'POST', null, callback);
 };
 
 /**
@@ -141,7 +141,7 @@ AdminClient.prototype.resendSenderSignatureConfirmation = function(id, callback)
  * @deprecated verifyDomainSPF replaces this method 
  */
 AdminClient.prototype.verifySenderSignatureSPF = function(id, callback) {
-  this.processRequestWithBody('/senders/' + id + '/verifyspf', 'POST', null, callback);
+  return this.processRequestWithBody('/senders/' + id + '/verifyspf', 'POST', null, callback);
 };
 
 /**
@@ -154,7 +154,7 @@ AdminClient.prototype.verifySenderSignatureSPF = function(id, callback) {
  * @deprecated rotateDKIMForDomain replaces this method
  */
 AdminClient.prototype.requestNewDKIMForSenderSignature = function(id, callback) {
-  this.processRequestWithBody('/senders/' + id + '/requestnewdkim', 'POST', null, callback);
+  return this.processRequestWithBody('/senders/' + id + '/requestnewdkim', 'POST', null, callback);
 };
 
 /**
@@ -166,7 +166,7 @@ AdminClient.prototype.requestNewDKIMForSenderSignature = function(id, callback) 
  * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
  */
 AdminClient.prototype.getServer = function(id, callback) {
-  this.processRequestWithoutBody('/servers/' + id, 'GET', null, callback);
+  return this.processRequestWithoutBody('/servers/' + id, 'GET', null, callback);
 };
 
 /**
@@ -178,7 +178,7 @@ AdminClient.prototype.getServer = function(id, callback) {
  * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
  */
 AdminClient.prototype.createServer = function(options, callback) {
-  this.processRequestWithBody('/servers/', 'POST', options, callback);
+  return this.processRequestWithBody('/servers/', 'POST', options, callback);
 };
 
 /**
@@ -191,7 +191,7 @@ AdminClient.prototype.createServer = function(options, callback) {
  * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
  */
 AdminClient.prototype.editServer = function(id, options, callback) {
-  this.processRequestWithBody('/servers/' + id, 'PUT', options, callback);
+  return this.processRequestWithBody('/servers/' + id, 'PUT', options, callback);
 };
 
 /**
@@ -205,7 +205,7 @@ AdminClient.prototype.editServer = function(id, options, callback) {
  * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
  */
 AdminClient.prototype.deleteServer = function(id, callback) {
-  this.processRequestWithoutBody('/servers/' + id, 'DELETE', null, callback);
+  return this.processRequestWithoutBody('/servers/' + id, 'DELETE', null, callback);
 };
 
 /**
@@ -222,7 +222,7 @@ AdminClient.prototype.listServers = function(query, callback) {
     count: 100,
     offset: 0
   }, query);
-  this.processRequestWithoutBody('/servers/', 'GET', query, callback);
+  return this.processRequestWithoutBody('/servers/', 'GET', query, callback);
 };
 
 /**
@@ -240,7 +240,7 @@ AdminClient.prototype.listDomains = function(query, callback) {
     count: 100,
     offset: 0
   }, query);
-  this.processRequestWithoutBody('/domains', 'GET', query, callback);
+  return this.processRequestWithoutBody('/domains', 'GET', query, callback);
 };
 
 /**
@@ -252,7 +252,7 @@ AdminClient.prototype.listDomains = function(query, callback) {
  * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
  */
 AdminClient.prototype.getDomain = function(id, callback) {
-  this.processRequestWithoutBody('/domains/' + id, 'GET', null, callback);
+  return this.processRequestWithoutBody('/domains/' + id, 'GET', null, callback);
 };
 
 /**
@@ -264,7 +264,7 @@ AdminClient.prototype.getDomain = function(id, callback) {
  * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
  */
 AdminClient.prototype.createDomain = function(options, callback) {
-  this.processRequestWithBody('/domains/', 'POST', options, callback);
+  return this.processRequestWithBody('/domains/', 'POST', options, callback);
 };
 
 /**
@@ -277,7 +277,7 @@ AdminClient.prototype.createDomain = function(options, callback) {
  * @param {postmarkCallback} callback A standard callback that is called when the API request completes.
  */
 AdminClient.prototype.editDomain = function(id, options, callback) {
-  this.processRequestWithBody('/domains/' + id, 'PUT', options, callback);
+  return this.processRequestWithBody('/domains/' + id, 'PUT', options, callback);
 };
 
 /**
@@ -289,7 +289,7 @@ AdminClient.prototype.editDomain = function(id, options, callback) {
  * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
  */
 AdminClient.prototype.deleteDomain = function(id, callback) {
-  this.processRequestWithoutBody('/domains/' + id, 'DELETE', null, callback);
+  return this.processRequestWithoutBody('/domains/' + id, 'DELETE', null, callback);
 };
 
 /**
@@ -301,7 +301,7 @@ AdminClient.prototype.deleteDomain = function(id, callback) {
  * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
  */
 AdminClient.prototype.verifyDomainSPF = function(id, callback) {
-  this.processRequestWithBody('/domains/' + id + '/verifyspf', 'POST', null, callback);
+  return this.processRequestWithBody('/domains/' + id + '/verifyspf', 'POST', null, callback);
 };
 
 /**
@@ -313,7 +313,7 @@ AdminClient.prototype.verifyDomainSPF = function(id, callback) {
  * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
  */
 AdminClient.prototype.rotateDKIMForDomain = function(id, callback) {
-  this.processRequestWithBody('/domains/' + id + '/rotatedkim', 'POST', null, callback);
+  return this.processRequestWithBody('/domains/' + id + '/rotatedkim', 'POST', null, callback);
 };
 
 module.exports = AdminClient;

--- a/lib/postmark/Client.js
+++ b/lib/postmark/Client.js
@@ -52,7 +52,7 @@
         if (query) {
             path += '?' + querystring.stringify(query);
         }
-        this.processRequestWithBody(path, type, null, callback);
+        return this.processRequestWithBody(path, type, null, callback);
     }
 
     /**
@@ -65,7 +65,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.send = function(message, callback) {
-        this.processRequestWithBody('/email', 'POST', message, callback);
+        return this.processRequestWithBody('/email', 'POST', message, callback);
     };
 
 
@@ -78,7 +78,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.sendEmailWithTemplate = function(message, callback) {
-        this.processRequestWithBody('/email/withTemplate', 'POST', message, callback);
+        return this.processRequestWithBody('/email/withTemplate', 'POST', message, callback);
     };
 
     /**
@@ -91,7 +91,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.batch = function(messages, callback) {
-        this.processRequestWithBody('/email/batch', 'POST', messages, callback);
+        return this.processRequestWithBody('/email/batch', 'POST', messages, callback);
     };
 
     /**
@@ -103,7 +103,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.sendEmail = function(message, callback) {
-        this.processRequestWithBody('/email', 'POST', message, callback);
+        return this.processRequestWithBody('/email', 'POST', message, callback);
     };
 
     /**
@@ -115,7 +115,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.sendEmailBatch = function(messages, callback) {
-        this.processRequestWithBody('/email/batch', 'POST', messages, callback);
+        return this.processRequestWithBody('/email/batch', 'POST', messages, callback);
     };
 
     /**
@@ -126,7 +126,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.getDeliveryStatistics = function(callback) {
-        this.processRequestWithoutBody('/deliverystats', 'GET', null, callback);
+        return this.processRequestWithoutBody('/deliverystats', 'GET', null, callback);
     };
 
     /**
@@ -144,7 +144,7 @@
             offset: 0
         }, filter);
 
-        this.processRequestWithoutBody('/bounces', 'GET', filter, callback);
+        return this.processRequestWithoutBody('/bounces', 'GET', filter, callback);
     };
 
     /**
@@ -156,7 +156,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.getBounce = function(id, callback) {
-        this.processRequestWithoutBody('/bounces/' + id, 'GET', null, callback);
+        return this.processRequestWithoutBody('/bounces/' + id, 'GET', null, callback);
     };
 
     /**
@@ -167,7 +167,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.getBounceDump = function(id, callback) {
-        this.processRequestWithoutBody('/bounces/' + id + '/dump', 'GET', null, callback);
+        return this.processRequestWithoutBody('/bounces/' + id + '/dump', 'GET', null, callback);
     };
 
     /**
@@ -179,7 +179,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.activateBounce = function(id, callback) {
-        this.processRequestWithBody('/bounces/' + id + '/activate', 'PUT', null, callback);
+        return this.processRequestWithBody('/bounces/' + id + '/activate', 'PUT', null, callback);
     };
 
     /**
@@ -190,7 +190,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.getBounceTags = function(callback) {
-        this.processRequestWithoutBody('/bounces/tags', 'GET', null, callback);
+        return this.processRequestWithoutBody('/bounces/tags', 'GET', null, callback);
     };
 
     /**
@@ -201,7 +201,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.getServer = function(callback) {
-        this.processRequestWithoutBody('/server', 'GET', null, callback);
+        return this.processRequestWithoutBody('/server', 'GET', null, callback);
     };
 
     /**
@@ -213,7 +213,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.editServer = function(options, callback) {
-        this.processRequestWithBody('/server', 'PUT', options, callback);
+        return this.processRequestWithBody('/server', 'PUT', options, callback);
     };
 
     /**
@@ -231,7 +231,7 @@
             count: 100,
             offset: 0
         }, filter);
-        this.processRequestWithoutBody('/messages/outbound', 'GET', filter, callback);
+        return this.processRequestWithoutBody('/messages/outbound', 'GET', filter, callback);
     };
 
     /**
@@ -243,7 +243,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.getOutboundMessageDetails = function(id, callback) {
-        this.processRequestWithoutBody('/messages/outbound/' + id + '/details', 'GET', null, callback);
+        return this.processRequestWithoutBody('/messages/outbound/' + id + '/details', 'GET', null, callback);
     };
 
     /**
@@ -261,7 +261,7 @@
             count: 100,
             offset: 0
         }, filter);
-        this.processRequestWithoutBody('/messages/outbound/opens', 'GET', filter, callback);
+        return this.processRequestWithoutBody('/messages/outbound/opens', 'GET', filter, callback);
     };
 
     /**
@@ -279,7 +279,7 @@
             count: 100,
             offset: 0
         }, filter);
-        this.processRequestWithoutBody('/messages/outbound/opens/' + id, 'GET', filter, callback);
+        return this.processRequestWithoutBody('/messages/outbound/opens/' + id, 'GET', filter, callback);
     };
 
     /**
@@ -296,7 +296,7 @@
             count: 100,
             offset: 0
         }, filter);
-        this.processRequestWithoutBody('/messages/inbound', 'GET', filter, callback);
+        return this.processRequestWithoutBody('/messages/inbound', 'GET', filter, callback);
     };
 
     /**
@@ -308,7 +308,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.getInboundMessageDetails = function(id, callback) {
-        this.processRequestWithoutBody('/messages/inbound/' + id + '/details', 'GET', null, callback);
+        return this.processRequestWithoutBody('/messages/inbound/' + id + '/details', 'GET', null, callback);
     };
 
     /**
@@ -320,7 +320,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.bypassBlockedInboundMessage = function(id, callback) {
-        this.processRequestWithBody('/messages/inbound/' + id + '/bypass', 'PUT', null, callback);
+        return this.processRequestWithBody('/messages/inbound/' + id + '/bypass', 'PUT', null, callback);
     };
 
     /**
@@ -332,7 +332,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.retryInboundHookForMessage = function(id, callback) {
-        this.processRequestWithBody('/messages/inbound/' + id + '/retry', 'PUT', null, callback);
+        return this.processRequestWithBody('/messages/inbound/' + id + '/retry', 'PUT', null, callback);
     };
 
 
@@ -346,7 +346,7 @@
      */
     Client.prototype.getOuboundOverview = function(filter, callback) {
         callback = coalesceCallback(filter, callback);
-        this.processRequestWithoutBody('/stats/outbound', 'GET', filter, callback);
+        return this.processRequestWithoutBody('/stats/outbound', 'GET', filter, callback);
     };
 
     /**
@@ -359,7 +359,7 @@
      */
     Client.prototype.getSentCounts = function(filter, callback) {
         callback = coalesceCallback(filter, callback);
-        this.processRequestWithoutBody('/stats/outbound/sends', 'GET', filter, callback);
+        return this.processRequestWithoutBody('/stats/outbound/sends', 'GET', filter, callback);
     };
 
     /**
@@ -372,7 +372,7 @@
      */
     Client.prototype.getBounceCounts = function(filter, callback) {
         callback = coalesceCallback(filter, callback);
-        this.processRequestWithoutBody('/stats/outbound/bounces', 'GET', filter, callback);
+        return this.processRequestWithoutBody('/stats/outbound/bounces', 'GET', filter, callback);
     };
 
     /**
@@ -385,7 +385,7 @@
      */
     Client.prototype.getSpamComplaints = function(filter, callback) {
         callback = coalesceCallback(filter, callback);
-        this.processRequestWithoutBody('/stats/outbound/spam', 'GET', filter, callback);
+        return this.processRequestWithoutBody('/stats/outbound/spam', 'GET', filter, callback);
     };
 
     /**
@@ -398,7 +398,7 @@
      */
     Client.prototype.getTrackedEmailCounts = function(filter, callback) {
         callback = coalesceCallback(filter, callback);
-        this.processRequestWithoutBody('/stats/outbound/tracked', 'GET', filter, callback);
+        return this.processRequestWithoutBody('/stats/outbound/tracked', 'GET', filter, callback);
     };
 
     /**
@@ -411,7 +411,7 @@
      */
     Client.prototype.getEmailOpenCounts = function(filter, callback) {
         callback = coalesceCallback(filter, callback);
-        this.processRequestWithoutBody('/stats/outbound/opens', 'GET', filter, callback);
+        return this.processRequestWithoutBody('/stats/outbound/opens', 'GET', filter, callback);
     };
 
     /**
@@ -424,7 +424,7 @@
      */
     Client.prototype.getEmailPlatformUsage = function(filter, callback) {
         callback = coalesceCallback(filter, callback);
-        this.processRequestWithoutBody('/stats/outbound/opens/platforms', 'GET', filter, callback);
+        return this.processRequestWithoutBody('/stats/outbound/opens/platforms', 'GET', filter, callback);
     };
 
     /**
@@ -437,7 +437,7 @@
      */
     Client.prototype.getEmailClientUsage = function(filter, callback) {
         callback = coalesceCallback(filter, callback);
-        this.processRequestWithoutBody('/stats/outbound/opens/emailclients', 'GET', filter, callback);
+        return this.processRequestWithoutBody('/stats/outbound/opens/emailclients', 'GET', filter, callback);
     };
 
     /**
@@ -450,7 +450,7 @@
      */
     Client.prototype.getEmailReadTimes = function(filter, callback) {
         callback = coalesceCallback(filter, callback);
-        this.processRequestWithoutBody('/stats/outbound/opens/readtimes', 'GET', filter, callback);
+        return this.processRequestWithoutBody('/stats/outbound/opens/readtimes', 'GET', filter, callback);
     };
 
     /**
@@ -463,7 +463,7 @@
      */
     Client.prototype.getClickCounts = function(filter, callback) {
         callback = coalesceCallback(filter, callback);
-        this.processRequestWithoutBody('/stats/outbound/clicks', 'GET', filter, callback);
+        return this.processRequestWithoutBody('/stats/outbound/clicks', 'GET', filter, callback);
     };
 
     /**
@@ -476,7 +476,7 @@
      */
     Client.prototype.getBrowserUsage = function(filter, callback) {
         callback = coalesceCallback(filter, callback);
-        this.processRequestWithoutBody('/stats/outbound/clicks/browserfamilies', 'GET', filter, callback);
+        return this.processRequestWithoutBody('/stats/outbound/clicks/browserfamilies', 'GET', filter, callback);
     };
 
     /**
@@ -489,7 +489,7 @@
      */
     Client.prototype.getBrowserPlatforms = function(filter, callback) {
         callback = coalesceCallback(filter, callback);
-        this.processRequestWithoutBody('/stats/outbound/clicks/platforms', 'GET', filter, callback);
+        return this.processRequestWithoutBody('/stats/outbound/clicks/platforms', 'GET', filter, callback);
     };
 
       /**
@@ -503,7 +503,7 @@
      */
     Client.prototype.getClickLocation = function(filter, callback) {
         callback = coalesceCallback(filter, callback);
-        this.processRequestWithoutBody('/stats/outbound/clicks/location', 'GET', filter, callback);
+        return this.processRequestWithoutBody('/stats/outbound/clicks/location', 'GET', filter, callback);
     };
 
     /**
@@ -515,7 +515,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.createTagTrigger = function(options, callback) {
-        this.processRequestWithBody('/triggers/tags', 'POST', options, callback);
+        return this.processRequestWithBody('/triggers/tags', 'POST', options, callback);
     };
 
     /**
@@ -540,7 +540,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.deleteTagTrigger = function(id, callback) {
-        this.processRequestWithoutBody('/triggers/tags/' + id, 'DELETE', null, callback);
+        return this.processRequestWithoutBody('/triggers/tags/' + id, 'DELETE', null, callback);
     };
 
     /**
@@ -552,7 +552,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.getTagTrigger = function(id, callback) {
-        this.processRequestWithoutBody('/triggers/tags/' + id, 'GET', null, callback);
+        return this.processRequestWithoutBody('/triggers/tags/' + id, 'GET', null, callback);
     };
 
     /**
@@ -570,7 +570,7 @@
             count: 100,
             offset: 0
         }, filter);
-        this.processRequestWithoutBody('/triggers/tags/', 'GET', filter, callback);
+        return this.processRequestWithoutBody('/triggers/tags/', 'GET', filter, callback);
     };
 
     /**
@@ -582,7 +582,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.createInboundRuleTrigger = function(options, callback) {
-        this.processRequestWithBody('/triggers/inboundrules', 'POST', options, callback);
+        return this.processRequestWithBody('/triggers/inboundrules', 'POST', options, callback);
     };
 
     /**
@@ -594,7 +594,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.deleteInboundRuleTrigger = function(id, callback) {
-        this.processRequestWithoutBody('/triggers/inboundrules/' + id, 'DELETE', null, callback);
+        return this.processRequestWithoutBody('/triggers/inboundrules/' + id, 'DELETE', null, callback);
     };
 
     /**
@@ -612,7 +612,7 @@
             count: 100,
             offset: 0
         }, filter);
-        this.processRequestWithoutBody('/triggers/inboundrules', 'GET', filter, callback);
+        return this.processRequestWithoutBody('/triggers/inboundrules', 'GET', filter, callback);
     };
 
     /**
@@ -629,7 +629,7 @@
             count: 100,
             offset: 0
         }, options);
-        this.processRequestWithoutBody('/templates', 'GET', options, callback);
+        return this.processRequestWithoutBody('/templates', 'GET', options, callback);
     };
 
 
@@ -642,7 +642,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.getTemplate = function(id, callback) {
-        this.processRequestWithoutBody('/templates/' + id, 'GET', null, callback);
+        return this.processRequestWithoutBody('/templates/' + id, 'GET', null, callback);
     };
 
     /**
@@ -654,7 +654,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.deleteTemplate = function(id, callback) {
-        this.processRequestWithoutBody('/templates/' + id, 'DELETE', null, callback);
+        return this.processRequestWithoutBody('/templates/' + id, 'DELETE', null, callback);
     }
 
     /**
@@ -666,7 +666,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.createTemplate = function(template, callback) {
-        this.processRequestWithBody('/templates/', 'POST', template, callback);
+        return this.processRequestWithBody('/templates/', 'POST', template, callback);
     }
 
     /**
@@ -679,7 +679,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.editTemplate = function(id, template, callback) {
-        this.processRequestWithBody('/templates/' + id, 'PUT', template, callback);
+        return this.processRequestWithBody('/templates/' + id, 'PUT', template, callback);
     }
 
     /**
@@ -692,7 +692,7 @@
      * @param {PostmarkCallback} callback A standard callback that is called when the API request completes.
      */
     Client.prototype.validateTemplate = function(templateContent, callback) {
-        this.processRequestWithBody('/templates/validate', 'POST', templateContent, callback);
+        return this.processRequestWithBody('/templates/validate', 'POST', templateContent, callback);
     }
 
     module.exports = Client;

--- a/lib/postmark/clientDefaults.js
+++ b/lib/postmark/clientDefaults.js
@@ -22,7 +22,7 @@ var ClientDefaults = {
   requestFactory: function(options) {
     var client = require('http' + (options.ssl === true ? 's' : ''));
 
-    return function(path, type, content, callback) {
+    function request(path, type, content, callback) {
       var msg = null;
       if (content) {
         msg = JSON.stringify(content);
@@ -98,6 +98,20 @@ var ClientDefaults = {
       }
       req.end();
     }
+
+    return function(path, type, content, callback) {
+      if (callback || typeof Promise === 'undefined') {
+        request(path, type, content, callback);
+      }
+      else {
+        return new Promise(function(resolve, reject) {
+          request(path, type, content, function(error, result) {
+            if (error) reject(error);
+            else resolve(result);
+          });
+        });
+      }
+    };
   }
 };
 


### PR DESCRIPTION
With this PR, if a callback is omitted a promise is returned (unless Promise is undefined as in Node 0.8). Possibly we could support user defined promise libraries by using `defaults.Promise` if defined?

I haven't updated the tests as yet... in fact I'm finding it hard to actually run the existing tests as there's no documentation or explanation of to configure them.