### PR TITLE
Use real errors in callbacks to match node.js callback pattern

### DIFF
--- a/lib/postmark/clientDefaults.js
+++ b/lib/postmark/clientDefaults.js
@@ -71,17 +71,15 @@ var ClientDefaults = {
               var data;
               try {
                 data = JSON.parse(body);
-                callback({
-                  status: response.statusCode,
-                  message: data.Message,
-                  code: data.ErrorCode
-                });
+                var err = new Error(data.Message);
+                err.status = response.statusCode;
+                err.code = data.ErrorCode;
+                callback(err);
               } catch (e) {
-                callback({
-                  status: 404,
-                  message: "Unsupported Request Method and Protocol",
-                  code: -1 // this is a fake error code !
-                });
+                var err = new Error("Unsupported Request Method and Protocol");
+                err.status = 404;
+                err.code = -1; // this is a fake error code !
+                callback(err);
               }
 
             }


### PR DESCRIPTION
Using these plain objects meant that there was no stack trace attached to messages, making it hard to track down where the error was created.  The standard callback pattern for node.js is always to use an `Error` as the first argument, never a plain object that indicates an error.