### PR TITLE
Correct spelling and link to license

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ Please leave all comments, bugs, requests and issues on the Issues page.
 
 ## License
 
-The Postmark Java Library is licensed under the **MIT** license. Please refer to the [LICENSE](https://github.com/wildbit/postmark-java/blob/master/LICENSE) for more information.
+The Postmark JavaScript Library is licensed under the **MIT** license. Please refer to the [LICENSE](https://github.com/wildbit/postmark.js/blob/master/LICENSE) for more information.


### PR DESCRIPTION
Changed "Java" to "JavaScript" and corrected link to the License in this repo, instead of the postmark-java repo.