### PR TITLE
Remove request library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "postmark",
-  "version": "2.3.0",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -109,17 +109,6 @@
       "integrity": "sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ==",
       "dev": true
     },
-    "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-      "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
-      }
-    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -153,19 +142,6 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -178,20 +154,13 @@
       "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
       "dev": true
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -240,14 +209,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -275,11 +236,6 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
       "version": "4.2.0",
@@ -323,11 +279,6 @@
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -342,14 +293,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
-    },
-    "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
     },
     "commander": {
       "version": "2.15.1",
@@ -378,7 +321,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cross-spawn": {
       "version": "5.1.0",
@@ -391,19 +335,10 @@
         "which": "^1.2.9"
       }
     },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -417,25 +352,11 @@
         "type-detect": "^4.0.0"
       }
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
-    },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -455,39 +376,12 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "debug": "=3.1.0"
       }
     },
     "fs-extra": {
@@ -512,14 +406,6 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
     },
     "glob": {
       "version": "7.1.2",
@@ -548,29 +434,15 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
-      "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.3.tgz",
+      "integrity": "sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
-      }
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
-      "requires": {
-        "ajv": "^5.3.0",
-        "har-schema": "^2.0.0"
       }
     },
     "has-ansi": {
@@ -600,16 +472,6 @@
       "integrity": "sha512-M0zZvfLr5p0keDMCAhNBp03XJbKBxUx5AfyfufMdFMEP4N/Xj6dh0IqC75ys7BAzceR34NgcvXjupRVaHBPPVQ==",
       "dev": true
     },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      }
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -638,11 +500,6 @@
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
       "dev": true
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -654,11 +511,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jquery": {
       "version": "3.4.1",
@@ -682,26 +534,6 @@
         "esprima": "^4.0.0"
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -709,17 +541,6 @@
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
       }
     },
     "just-extend": {
@@ -768,19 +589,6 @@
       "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
       "dev": true
     },
-    "mime-db": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
-    },
-    "mime-types": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
-      "requires": {
-        "mime-db": "~1.37.0"
-      }
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -827,8 +635,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nconf": {
       "version": "0.7.1",
@@ -859,11 +666,6 @@
         "lolex": "^4.1.0",
         "path-to-regexp": "^1.7.0"
       }
-    },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "once": {
       "version": "1.4.0",
@@ -925,11 +727,6 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "pre-commit": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
@@ -959,21 +756,6 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
-    "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
-    },
-    "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-    },
-    "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-    },
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -998,33 +780,6 @@
         "resolve": "^1.1.6"
       }
     },
-    "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      }
-    },
     "resolve": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
@@ -1037,12 +792,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "semver": {
       "version": "5.6.0",
@@ -1134,22 +885,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "sshpk": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
-    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -1175,15 +910,6 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
-      }
-    },
-    "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-      "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
       }
     },
     "ts-node": {
@@ -1245,19 +971,6 @@
         "tslib": "^1.8.1"
       }
     },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -1316,20 +1029,20 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.1.tgz",
-      "integrity": "sha512-+dSJLJpXBb6oMHP+Yvw8hUgElz4gLTh82XuX68QiJVTXaE5ibl6buzhNkQdYhBlIhozWOC9ge16wyRmjG4TwVQ==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
+      "integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true,
           "optional": true
         }
@@ -1352,21 +1065,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
-    },
-    "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
     },
     "which": {
       "version": "1.2.14",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "sending",
     "transactional"
   ],
-  "version": "2.3.5",
+  "version": "2.5.0",
   "author": "Igor Balos",
   "contributors": [
     "Aaron Blum",
@@ -80,6 +80,6 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "request": "^2.88.0"
+    "axios": "^0.19.2"
   }
 }

--- a/src/client/BaseClient.ts
+++ b/src/client/BaseClient.ts
@@ -28,7 +28,7 @@ export default abstract class BaseClient {
     protected errorHandler: ErrorHandler;
     private readonly authHeader: string;
     private readonly token: string;
-    private httpClient: AxiosInstance;
+    public readonly httpClient: AxiosInstance;
 
     protected constructor(token: string, authHeader: string, configOptions?: ClientOptions.Configuration) {
         this.clientVersion = CLIENT_VERSION;

--- a/src/client/BaseClient.ts
+++ b/src/client/BaseClient.ts
@@ -1,4 +1,4 @@
-import * as request from "request";
+import axios, {AxiosError, AxiosResponse} from "axios";
 
 import { ErrorHandler } from "./ErrorHandler";
 import {Callback, ClientOptions, FilteringParameters} from "./models";
@@ -108,35 +108,13 @@ export default abstract class BaseClient {
      * @returns A promise that will complete when the API responds (or an error occurs).
      */
     private processHttpRequest<T>(method: ClientOptions.HttpMethod, path: string, queryParameters: object, body: (null | object)): Promise<T> {
-        return this.promisifiedHttpRequest(method, path, queryParameters, body)
-            .then((response) => {
-                return response.body as T;
+        return this.httpRequest(method, path, queryParameters, body)
+            .then((response: AxiosResponse) => {
+                return response.data as T;
             })
-            .catch((error) => {
-                throw this.errorHandler.generateError(error);
+            .catch((error: AxiosError) => {
+                throw this.errorHandler.buildRequestError(error);
             });
-    }
-
-    /**
-     * Handle http request to return it as Promise.
-     *
-     * @param method - Which type of http request will be executed.
-     * @param path - API URL endpoint.
-     * @param queryParameters - Querystring parameters used for http request.
-     * @param body - Data sent with http request.
-     *
-     * @returns A promise that will complete when the API responds.
-     */
-    private promisifiedHttpRequest(method: ClientOptions.HttpMethod, path: string, queryParameters: ({} | object),
-                                   body: (null | object)): Promise<request.Response> {
-
-        return new Promise((resolve, reject) => {
-            this.httpRequest(method, path, queryParameters, body, (error: Error, response: request.Response) => {
-                if (error) { reject(error); } else {
-                    if (response.statusCode !== 200) { reject(response); } else { resolve(response); }
-                }
-            });
-        });
     }
 
     /**
@@ -148,9 +126,7 @@ export default abstract class BaseClient {
     private processCallbackRequest<T>(httpRequest: Promise<T>, callback?: Callback<T>): void {
         if (callback) {
             httpRequest
-                .then((response) => {
-                    callback(null, response);
-                })
+                .then((response) => { callback(null, response); })
                 .catch((error) => callback(error, null));
         }
     }
@@ -164,25 +140,33 @@ export default abstract class BaseClient {
      * @param body - Data sent with http request.
      */
     private httpRequest(method: ClientOptions.HttpMethod, path: string, queryParameters: ({} | object),
-                        body: (null | object), callback: any): void {
-        request(this.getHttpRequestURL(path), {
-            method: method.toString(),
+                        body: (null | object)): Promise<AxiosResponse> {
+        return axios.request({
+            method,
             headers: this.getComposedHttpRequestHeaders(),
-            qs: queryParameters,
-            body,
+            baseURL: this.getBaseHttpRequestURL(),
+            url: path,
+            params: queryParameters,
             timeout: this.getRequestTimeoutInSeconds(),
-            json: true,
-            gzip: true,
-        }, callback);
+            responseType: "json",
+            data: body,
+            validateStatus(status) {
+                return status >= 200 && status < 300;
+            },
+        });
     }
 
     private getRequestTimeoutInSeconds(): number {
         return (this.clientOptions.timeout || 30) * 1000;
     }
 
-    private getHttpRequestURL(path: string): string {
+    private getBaseHttpRequestURL(): string {
         const scheme = this.clientOptions.useHttps ? "https" : "http";
-        return `${scheme}://${this.clientOptions.requestHost}${path}`;
+        return `${scheme}://${this.clientOptions.requestHost}`;
+    }
+
+    private getHttpRequestURL(path: string): string {
+        return `${this.getBaseHttpRequestURL()}${path}`;
     }
 
     /**
@@ -192,7 +176,7 @@ export default abstract class BaseClient {
      */
     private verifyToken(token: string): void {
         if (!token || token.trim() === "") {
-            throw this.errorHandler.generateError(new Error("A valid API token must be provided."));
+            throw this.errorHandler.buildGeneralError("A valid API token must be provided.");
         }
     }
 }

--- a/src/client/ErrorHandler.ts
+++ b/src/client/ErrorHandler.ts
@@ -3,7 +3,7 @@ import {DefaultResponse} from "./models";
 import * as Errors from "./models/client/Errors";
 
 /**
- * This class handles general errors and all client request errors.
+ * Handles general errors and all client request errors.
  * Client response errors are classified so that proper response error is generated.
  */
 export class ErrorHandler {

--- a/test/unit/AccountClient.test.ts
+++ b/test/unit/AccountClient.test.ts
@@ -10,8 +10,6 @@ const testingKeys = nconf.env().file({ file: __dirname + "/../../testing_keys.js
 const packageJson = require("../../package.json");
 const clientVersion = packageJson.version;
 
-import axios from "axios";
-
 describe("AccountClient", () => {
     let client: postmark.AccountClient;
     const accountToken: string = testingKeys.get("ACCOUNT_TOKEN");
@@ -79,7 +77,7 @@ describe("AccountClient", () => {
 
             it("promise error", () => {
                 client = new postmark.AccountClient(serverToken);
-                sandbox.stub(axios, "request").rejects(rejectError);
+                sandbox.stub(client.httpClient, "request").rejects(rejectError);
 
                 return client.getSenderSignatures().then((result) => {
                     throw Error(`Should not be here with result: ${result}`);
@@ -90,7 +88,7 @@ describe("AccountClient", () => {
 
             it("callback error", (done) => {
                 client = new postmark.AccountClient("testToken");
-                sandbox.stub(axios, "request").rejects(rejectError);
+                sandbox.stub(client.httpClient, "request").rejects(rejectError);
 
                 client.getSenderSignatures(undefined, (error: any, data) => {
                     expect(data).to.equal(null);

--- a/test/unit/AccountClient.test.ts
+++ b/test/unit/AccountClient.test.ts
@@ -76,7 +76,7 @@ describe("AccountClient", () => {
 
             it("promise error", () => {
                 client = new postmark.AccountClient("testToken");
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").yields(undefined, {statusCode: 401, body: 'response'});
+                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects({response: {status: 401, data: 'response'}});
 
                 return client.getSenderSignatures().then((result) => {
                     throw Error(`Should not be here with result: ${result}`);
@@ -87,7 +87,7 @@ describe("AccountClient", () => {
 
             it("callback error", (done) => {
                 client = new postmark.AccountClient("testToken");
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").yields(undefined, {statusCode: 401, body: 'response'});
+                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects({response: {status: 401, data: 'response'}});
 
                 client.getSenderSignatures(undefined, (error: any, data) => {
                     expect(data).to.equal(null);

--- a/test/unit/ErrorHandler.test.ts
+++ b/test/unit/ErrorHandler.test.ts
@@ -5,14 +5,14 @@ import { expect } from "chai";
 import "mocha";
 
 describe("ErrorHandler", () => {
-    it("generateError", () => {
+    it("buildGeneralError", () => {
         const errorHandler = new ErrorHandler();
 
         const error = new Error();
         error.name = "Test name";
         error.message = "Test message";
 
-        const postmarkError = errorHandler.generateError(error);
+        const postmarkError = errorHandler.buildGeneralError("Test message");
         expect(postmarkError.message).to.equal(error.message);
         expect(postmarkError.name).to.equal("PostmarkError");
     });
@@ -22,83 +22,102 @@ describe("ErrorHandler", () => {
             const errorHandler = new ErrorHandler();
 
             const error: any = {
-                name: "Test name",
-                body: {
-                    Message: "Test message",
-                    ErrorCode: 401,
-                },
-                statusCode: 401,
+                response: {
+                    data: {
+                        Message: "Test message",
+                        ErrorCode: 401,
+                    },
+                    status: 401,
+                }
             };
 
-            const postmarkError = errorHandler.generateError(error);
+            const postmarkError = errorHandler.buildRequestError(error);
             expect(postmarkError).to.be.an.instanceof(Errors.InvalidAPIKeyError);
             expect(postmarkError.name).to.equal("InvalidAPIKeyError");
-            expect(postmarkError.message).to.equal(error.body.Message);
+            expect(postmarkError.message).to.equal(error.response.data.Message);
         });
 
         it("422", () => {
             const errorHandler = new ErrorHandler();
 
             const error: any = {
-                name: "Test name",
-                body: {
-                    Message: "Test message",
-                    ErrorCode: 422,
-                },
-                statusCode: 422,
+                response: {
+                    data: {
+                        Message: "Test message",
+                        ErrorCode: 422,
+                    },
+                    status: 422,
+                }
             };
 
-            const postmarkError = errorHandler.generateError(error);
+            const postmarkError = errorHandler.buildRequestError(error);
             expect(postmarkError).to.be.an.instanceof(Errors.ApiInputError);
             expect(postmarkError.name).to.equal("ApiInputError");
-            expect(postmarkError.message).to.equal(error.body.Message);
+            expect(postmarkError.message).to.equal(error.response.data.Message);
         });
 
         it("500", () => {
             const errorHandler = new ErrorHandler();
 
             const error: any = {
-                name: "Test name",
-                body: {
-                    Message: "Test message",
-                    ErrorCode: 500,
-                },
-                statusCode: 500,
+                response: {
+                    data: {
+                        Message: "Test message",
+                        ErrorCode: 500,
+                    },
+                    status: 500,
+                }
             };
 
-            const postmarkError = errorHandler.generateError(error);
+            const postmarkError = errorHandler.buildRequestError(error);
             expect(postmarkError).to.be.an.instanceof(Errors.InternalServerError);
             expect(postmarkError.name).to.equal("InternalServerError");
-            expect(postmarkError.message).to.equal(error.body.Message);
+            expect(postmarkError.message).to.equal(error.response.data.Message);
         });
 
         it("unknown", () => {
             const errorHandler = new ErrorHandler();
 
             const error: any = {
-                name: "Test name",
-                message: "test message",
-                statusCode: 600,
+                response: {
+                    data: {
+                        Message: "Test message",
+                        ErrorCode: 600,
+                    },
+                    status: 600,
+                }
             };
 
-            const postmarkError = errorHandler.generateError(error);
+            const postmarkError = errorHandler.buildRequestError(error);
             expect(postmarkError).to.be.an.instanceof(Errors.PostmarkError);
             expect(postmarkError.name).to.equal("UnknownError");
-            expect(postmarkError.message).to.equal(error.message);
+            expect(postmarkError.message).to.equal(error.response.data.Message);
         });
 
-        it("postmark error", () => {
+        it("no status", () => {
             const errorHandler = new ErrorHandler();
 
             const error: any = {
-                name: "Test name",
-                message: "test message"
+                response: {
+                    data: {
+                        Message: "Test message"
+                    }
+                }
             };
 
-            const postmarkError = errorHandler.generateError(error);
+            const postmarkError = errorHandler.buildRequestError(error);
+            expect(postmarkError).to.be.an.instanceof(Errors.PostmarkError);
+            expect(postmarkError.name).to.equal("UnknownError");
+            expect(postmarkError.message).to.equal(error.response.data.Message);
+        });
+
+        it("postmark default error", () => {
+            const errorHandler = new ErrorHandler();
+
+            const postmarkError = errorHandler.buildGeneralError("Test message");
             expect(postmarkError).to.be.an.instanceof(Errors.PostmarkError);
             expect(postmarkError.name).to.equal("PostmarkError");
-            expect(postmarkError.message).to.equal(error.message);
+            expect(postmarkError.message).to.equal("Test message");
         });
     });
 });

--- a/test/unit/ServerClient.test.ts
+++ b/test/unit/ServerClient.test.ts
@@ -9,7 +9,6 @@ const testingKeys = nconf.env().file({file: __dirname + "/../../testing_keys.jso
 const packageJson = require("../../package.json");
 const clientVersion = packageJson.version;
 import * as sinon from 'sinon';
-import axios from "axios";
 
 describe("ServerClient", () => {
     let client: postmark.ServerClient;
@@ -109,14 +108,14 @@ describe("ServerClient", () => {
         describe("callback", () => {
             it('process it when there are no errors', async() => {
                 let callback = sinon.spy();
-                sandbox.stub(axios, "request").returns(Promise.resolve("test"));
+                sandbox.stub(client.httpClient, "request").returns(Promise.resolve("test"));
 
                 await client.getServer(callback);
                 expect(callback.calledOnce).to.be.true
             });
 
             it('process regular response based on request status', () => {
-                sandbox.stub(axios, "request").returns(Promise.resolve("test"));
+                sandbox.stub(client.httpClient, "request").returns(Promise.resolve("test"));
 
                 return client.getServer().then((result) => {
                     expect(result).to.eq('test');
@@ -126,7 +125,7 @@ describe("ServerClient", () => {
             });
             
             it('process error response based on request status',  () => {
-                sandbox.stub(axios, "request").rejects({response: {status: 600, data: 'response'}});
+                sandbox.stub(client.httpClient, "request").rejects({response: {status: 600, data: 'response'}});
 
                 return client.getServer().then((result) => {
                     throw Error(`Should not be here with result: ${result}`);

--- a/test/unit/ServerClient.test.ts
+++ b/test/unit/ServerClient.test.ts
@@ -128,16 +128,15 @@ describe("ServerClient", () => {
                 expect(callback.calledOnce).to.be.true
             });
 
-            it('process regular response based on request status', () => {
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").yields(undefined, {statusCode: 200, body: 'response'});
-
+            it('process regular response based on request status', async () => {
+                sandbox.stub(BaseClient.prototype, <any> "processHttpRequest").returns(new Promise( function(resolve) { resolve("test"); }));
                 return client.getServer( (error, result) => {
-                    expect(result).to.eq('response');
+                    expect(result).to.eq('test');
                 });
             });
             
             it('process error response based on request status',  () => {
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").yields(undefined, {statusCode: 201, body: 'response'});
+                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects( {response: {data: {status: 201, message: 'response'}}});
 
                 return client.getServer( (error: any, result) => {
                     expect(error.name).to.eq('UnknownError');

--- a/test/unit/ServerClient.test.ts
+++ b/test/unit/ServerClient.test.ts
@@ -21,11 +21,8 @@ describe("ServerClient", () => {
 
     describe("#new", () => {
         it("default clientOptions", () => {
-            expect(client.clientOptions).to.eql({
-                useHttps: true,
-                requestHost: "api.postmarkapp.com",
-                timeout: 30,
-            });
+            const defaultClientOptions = { useHttps: true, requestHost: "api.postmarkapp.com", timeout: 30 };
+            expect(client.clientOptions).to.eql(defaultClientOptions);
         });
 
         it("clientVersion", () => {
@@ -122,7 +119,7 @@ describe("ServerClient", () => {
         describe("callback", () => {
             it('process it when there are no errors', async() => {
                 let callback = sinon.spy();
-                sandbox.stub(BaseClient.prototype, <any> "processHttpRequest").returns(new Promise( function(resolve) { resolve("test"); }));
+                sandbox.stub(BaseClient.prototype, <any> "httpRequest").returns(new Promise( function(resolve) { resolve("test"); }));
                 await client.getServer(callback);
 
                 expect(callback.calledOnce).to.be.true

--- a/test/unit/ServerClientErrors.test.ts
+++ b/test/unit/ServerClientErrors.test.ts
@@ -31,7 +31,7 @@ describe("ServerClient - Errors", () => {
 
     describe("handling errors", () => {
         it("throw basic error - promise", () => {
-            sandbox.stub(BaseClient.prototype, <any> "httpRequest").throws(new Error("Basic error"));
+            sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects({ response: {data: "Basic error" }});
 
             const serverToken: string = testingKeys.get("SERVER_TOKEN");
             let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
@@ -47,7 +47,7 @@ describe("ServerClient - Errors", () => {
         it("throw api key error - promise", () => {
             let error: any = new Error("Basic error");
             error.statusCode = 401;
-            sandbox.stub(BaseClient.prototype, <any> "httpRequest").throws(error);
+            sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects({response: { data: "Basic error", status: 401}});
 
             const serverToken: string = testingKeys.get("SERVER_TOKEN");
             let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
@@ -60,10 +60,16 @@ describe("ServerClient - Errors", () => {
         });
 
         describe("http status code errors", () => {
+            let error: any = {
+                response: {
+                    data: "Basic error",
+                    status: 505
+                }
+            };
+
             it("404", () => {
-                let error: any = new Error("Basic error");
-                error.statusCode = 404;
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").throws(error);
+                error.response.status = 404;
+                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(error);
 
                 const serverToken: string = testingKeys.get("SERVER_TOKEN");
                 let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
@@ -76,9 +82,8 @@ describe("ServerClient - Errors", () => {
             });
 
             it("422", () => {
-                let error: any = new Error("Basic error");
-                error.statusCode = 422;
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").throws(error)
+                error.response.status = 422;
+                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(error);
 
                 const serverToken: string = testingKeys.get("SERVER_TOKEN");
                 let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
@@ -91,9 +96,8 @@ describe("ServerClient - Errors", () => {
             });
 
             it("500", () => {
-                let error: any = new Error("Basic error");
-                error.statusCode = 500;
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").throws(error);
+                error.response.status = 500;
+                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(error);
 
                 const serverToken: string = testingKeys.get("SERVER_TOKEN");
                 let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
@@ -106,9 +110,8 @@ describe("ServerClient - Errors", () => {
             });
 
             it("503", () => {
-                let error: any = new Error("Basic error");
-                error.statusCode = 503;
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").throws(error);
+                error.response.status = 503;
+                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(error);
 
                 const serverToken: string = testingKeys.get("SERVER_TOKEN");
                 let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
@@ -121,9 +124,8 @@ describe("ServerClient - Errors", () => {
             });
 
             it("505", () => {
-                let error: any = new Error("Basic error");
-                error.statusCode = 505;
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").throws(error);
+                error.response.status = 505;
+                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(error);
 
                 const serverToken: string = testingKeys.get("SERVER_TOKEN");
                 let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
@@ -137,7 +139,7 @@ describe("ServerClient - Errors", () => {
         });
 
         it("throw basic error - callback", (done) => {
-            sandbox.stub(BaseClient.prototype, <any> "httpRequest").throws(new Error("Basic error"));
+            sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects({ response: {data: "Basic error", status: 404}});
 
             const serverToken: string = testingKeys.get("SERVER_TOKEN");
             let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
@@ -156,7 +158,7 @@ describe("ServerClient - Errors", () => {
     });
 
     it("promise error", () => {
-        sandbox.stub(BaseClient.prototype, <any> "httpRequest").yields(undefined, {statusCode: 401, body: 'response'});
+        sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects({ response: { data: 'response', status: 401} });
 
         return client.getBounces().then((result) => {
             return result;
@@ -167,7 +169,7 @@ describe("ServerClient - Errors", () => {
 
     it("callback error", (done) => {
         client = new postmark.ServerClient("testToken");
-        sandbox.stub(BaseClient.prototype, <any> "httpRequest").yields(undefined, {statusCode: 401, body: 'response'});
+        sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects({ response: { data: 'response', status: 401} });
 
         client.getBounces(undefined, (error: any, data) => {
             expect(data).to.equal(null);

--- a/test/unit/ServerClientErrors.test.ts
+++ b/test/unit/ServerClientErrors.test.ts
@@ -89,16 +89,15 @@ describe("ServerClient - Errors", () => {
         });
 
         describe("http status code errors", () => {
-            let error: any = {
+            const buildError = (statusNumber: number) => ({
                 response: {
                     data: "Basic error",
-                    status: 505
+                    status: statusNumber
                 }
-            };
+            });
 
             it("401", () => {
-                error.response.status = 401;
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(error);
+                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(buildError(401));
 
                 const serverToken: string = testingKeys.get("SERVER_TOKEN");
                 let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
@@ -111,8 +110,7 @@ describe("ServerClient - Errors", () => {
             });
 
             it("404", () => {
-                error.response.status = 404;
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(error);
+                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(buildError(404));
 
                 const serverToken: string = testingKeys.get("SERVER_TOKEN");
                 let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
@@ -125,8 +123,7 @@ describe("ServerClient - Errors", () => {
             });
 
             it("422", () => {
-                error.response.status = 422;
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(error);
+                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(buildError(422));
 
                 const serverToken: string = testingKeys.get("SERVER_TOKEN");
                 let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
@@ -139,8 +136,7 @@ describe("ServerClient - Errors", () => {
             });
 
             it("500", () => {
-                error.response.status = 500;
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(error);
+                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(buildError(500));
 
                 const serverToken: string = testingKeys.get("SERVER_TOKEN");
                 let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
@@ -153,8 +149,7 @@ describe("ServerClient - Errors", () => {
             });
 
             it("503", () => {
-                error.response.status = 503;
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(error);
+                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(buildError(503));
 
                 const serverToken: string = testingKeys.get("SERVER_TOKEN");
                 let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
@@ -167,8 +162,7 @@ describe("ServerClient - Errors", () => {
             });
 
             it("505", () => {
-                error.response.status = 505;
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(error);
+                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(buildError(505));
 
                 const serverToken: string = testingKeys.get("SERVER_TOKEN");
                 let client: postmark.ServerClient = new postmark.ServerClient(serverToken);

--- a/test/unit/ServerClientErrors.test.ts
+++ b/test/unit/ServerClientErrors.test.ts
@@ -4,7 +4,6 @@ import {expect} from "chai";
 import "mocha";
 
 import * as nconf from "nconf";
-import BaseClient from "../../src/client/BaseClient";
 import * as sinon from 'sinon';
 
 const testingKeys = nconf.env().file({file: __dirname + "/../../testing_keys.json"});
@@ -30,12 +29,12 @@ describe("ServerClient - Errors", () => {
     });
 
     describe("handling errors", () => {
+        const serverToken: string = testingKeys.get("SERVER_TOKEN");
+        const client: postmark.ServerClient = new postmark.ServerClient(serverToken);
+
         describe("promise error", () => {
             it("instance", () => {
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects({ message: "Basic error", response: {data: "Basic error" }});
-
-                const serverToken: string = testingKeys.get("SERVER_TOKEN");
-                let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
+                sandbox.stub(client.httpClient, "request").rejects({ message: "Basic error", response: {data: "Basic error" }});
 
                 return client.getServer().then((result) => {
                     return result;
@@ -45,10 +44,7 @@ describe("ServerClient - Errors", () => {
             });
 
             it("message", () => {
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects({ message: "Basic error", response: {data: "Basic error" }});
-
-                const serverToken: string = testingKeys.get("SERVER_TOKEN");
-                let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
+                sandbox.stub(client.httpClient, "request").rejects({ message: "Basic error", response: {data: "Basic error" }});
 
                 return client.getServer().then((result) => {
                     return result;
@@ -58,7 +54,7 @@ describe("ServerClient - Errors", () => {
             });
 
             it("name", () => {
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects({ response: { data: 'response', status: 401} });
+                sandbox.stub(client.httpClient, "request").rejects({ response: { data: 'response', status: 401} });
 
                 return client.getBounces().then((result) => {
                     return result;
@@ -70,10 +66,7 @@ describe("ServerClient - Errors", () => {
 
         describe("callback error", () => {
             it("name", (done) => {
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects({ response: {data: "Basic error", status: 404}});
-
-                const serverToken: string = testingKeys.get("SERVER_TOKEN");
-                let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
+                sandbox.stub(client.httpClient, "request").rejects({ response: {data: "Basic error", status: 404}});
 
                 client.getServer((error: any, data) => {
                     expect(data).to.equal(null);
@@ -97,10 +90,7 @@ describe("ServerClient - Errors", () => {
             });
 
             it("401", () => {
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(buildError(401));
-
-                const serverToken: string = testingKeys.get("SERVER_TOKEN");
-                let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
+                sandbox.stub(client.httpClient, "request").rejects(buildError(401));
 
                 return client.getServer().then((result) => {
                     return result;
@@ -110,10 +100,7 @@ describe("ServerClient - Errors", () => {
             });
 
             it("404", () => {
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(buildError(404));
-
-                const serverToken: string = testingKeys.get("SERVER_TOKEN");
-                let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
+                sandbox.stub(client.httpClient, "request").rejects(buildError(404));
 
                 return client.getServer().then((result) => {
                     return result;
@@ -123,10 +110,7 @@ describe("ServerClient - Errors", () => {
             });
 
             it("422", () => {
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(buildError(422));
-
-                const serverToken: string = testingKeys.get("SERVER_TOKEN");
-                let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
+                sandbox.stub(client.httpClient, "request").rejects(buildError(422));
 
                 return client.getServer().then((result) => {
                     return result;
@@ -136,10 +120,7 @@ describe("ServerClient - Errors", () => {
             });
 
             it("500", () => {
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(buildError(500));
-
-                const serverToken: string = testingKeys.get("SERVER_TOKEN");
-                let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
+                sandbox.stub(client.httpClient, "request").rejects(buildError(500));
 
                 return client.getServer().then((result) => {
                     return result;
@@ -149,10 +130,7 @@ describe("ServerClient - Errors", () => {
             });
 
             it("503", () => {
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(buildError(503));
-
-                const serverToken: string = testingKeys.get("SERVER_TOKEN");
-                let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
+                sandbox.stub(client.httpClient, "request").rejects(buildError(503));
 
                 return client.getServer().then((result) => {
                     return result;
@@ -162,10 +140,7 @@ describe("ServerClient - Errors", () => {
             });
 
             it("505", () => {
-                sandbox.stub(BaseClient.prototype, <any> "httpRequest").rejects(buildError(505));
-
-                const serverToken: string = testingKeys.get("SERVER_TOKEN");
-                let client: postmark.ServerClient = new postmark.ServerClient(serverToken);
+                sandbox.stub(client.httpClient, "request").rejects(buildError(505));
 
                 return client.getServer().then((result) => {
                     return result;


### PR DESCRIPTION
Hey @tomazy 

could you take a quick look on this branch? Would love a pair of eyes to run through it even though its a small update, but touches main aspect of requests handling.

The update is related to http client library. [RequestJS](https://github.com/request/request) got deprecated. Due to popularity, ease of use, size, decided to go for [axios](https://github.com/axios/axios). 

Along the road error handling and tests were cleaned up a bit.