### PR TITLE
Name is mandatory according to docs and API

### DIFF
--- a/src/client/models/senders/Signature.ts
+++ b/src/client/models/senders/Signature.ts
@@ -36,7 +36,7 @@ export class UpdateSignatureRequest {
 }
 
 export class CreateSignatureRequest {
-    public Name?: string;
+    public Name: string;
     public FromEmail: string;
     public ReplyToEmail?: string;
     public ReturnPathDomain?: string;


### PR DESCRIPTION
According to the [docs](https://postmarkapp.com/developer/api/signatures-api#create-signature) this field is required. However in the `CreateSignatureRequest` it's not. This patch just makes it mandatory to avoid confusion when using the client.

Thanks for the great library!