### PR TITLE
Make MessageID mandatory

### DIFF
--- a/src/client/models/message/Message.ts
+++ b/src/client/models/message/Message.ts
@@ -46,5 +46,5 @@ export interface MessageSendingResponse extends DefaultResponse {
     Cc?: string;
     Bcc?: string;
     SubmittedAt: string;
-    MessageID?: string;
+    MessageID: string;
 }


### PR DESCRIPTION
As far as I understand, from your docs and after asking your customer support team, `MessageID` should always be in the response if it's a successful send. I'm just updating the `MessageSendingResponse` interface to reflect that.

If this is not the case, could you let me know in which scenarios could we not get a `MessageID` for a successful response from your API?