### PR TITLE
feat: replace axios with native fetch API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "postmark",
       "version": "4.0.7",
       "license": "MIT",
-      "dependencies": {
-        "axios": "^1.13.5"
-      },
       "devDependencies": {
         "@types/chai": "^4.3.11",
         "@types/mocha": "^10.0.6",
@@ -309,7 +306,8 @@
       "version": "12.20.55",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
       "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.6",
@@ -419,6 +417,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -675,6 +674,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -777,23 +777,6 @@
         "node": "*"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -842,19 +825,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -943,18 +913,6 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/concat-map": {
@@ -1048,15 +1006,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -1102,70 +1051,11 @@
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -1193,6 +1083,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.55.0.tgz",
       "integrity": "sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -1611,42 +1502,6 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1667,15 +1522,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1692,43 +1538,6 @@
       "dev": true,
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -1799,18 +1608,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -1824,45 +1621,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/he": {
@@ -2205,15 +1963,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2234,27 +1983,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -2656,11 +2384,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",
@@ -3119,6 +2842,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -78,8 +78,5 @@
     "ts-node": "^10.9.1",
     "typedoc": "^0.25.4",
     "typescript": "^4.7.4"
-  },
-  "dependencies": {
-    "axios": "^1.13.5"
   }
 }

--- a/src/client/BaseClient.ts
+++ b/src/client/BaseClient.ts
@@ -1,6 +1,6 @@
 import { ErrorHandler } from "./errors/ErrorHandler";
 import {Callback, ClientOptions, FilteringParameters, HttpClient} from "./models";
-import {AxiosHttpClient} from "./HttpClient"
+import {FetchHttpClient} from "./HttpClient"
 import {Errors} from "../index";
 
 const packageJson = require("../../package.json");
@@ -23,7 +23,7 @@ export default abstract class BaseClient {
         this.token = token.trim();
         this.authHeader = authHeader;
         this.clientVersion = CLIENT_VERSION;
-        this.httpClient = new AxiosHttpClient(configOptions);
+        this.httpClient = new FetchHttpClient(configOptions);
     }
 
     public setClientOptions(configOptions: ClientOptions.Configuration): void {

--- a/src/client/HttpClient.ts
+++ b/src/client/HttpClient.ts
@@ -1,9 +1,8 @@
-import axios, {AxiosInstance, AxiosError, AxiosResponse} from "axios";
 import {ClientOptions, HttpClient} from "./models";
 import {ErrorHandler, PostmarkError} from "./errors/index";
 
-export class AxiosHttpClient extends HttpClient {
-    public client!: AxiosInstance;
+export class FetchHttpClient extends HttpClient {
+    public client: any;
     private errorHandler: ErrorHandler;
 
     public constructor(configOptions?: ClientOptions.Configuration) {
@@ -13,25 +12,10 @@ export class AxiosHttpClient extends HttpClient {
 
     /**
      * Create http client instance with default settings.
-     *
-     * @return {AxiosInstance}
      */
     public initHttpClient(configOptions?: ClientOptions.Configuration): void {
         this.clientOptions = { ...HttpClient.DefaultOptions, ...configOptions };
-
-        const httpClient = axios.create({
-            baseURL: this.getBaseHttpRequestURL(),
-            timeout: this.getRequestTimeoutInMilliseconds(),
-            responseType: "json",
-            maxContentLength: Infinity,
-            maxBodyLength: Infinity,
-            validateStatus(status: number) {
-                return status >= 200 && status < 300;
-            },
-        });
-
-        httpClient.interceptors.response.use((response: any) => (response.data));
-        this.client = httpClient;
+        this.client = {};
     }
 
     /**
@@ -41,55 +25,120 @@ export class AxiosHttpClient extends HttpClient {
      * @param path - API URL endpoint.
      * @param queryParameters - Querystring parameters used for http request.
      * @param body - Data sent with http request.
+     * @param requestHeaders - Headers to include in the request.
      */
     public httpRequest<T>(method: ClientOptions.HttpMethod, path: string, queryParameters: object,
                            body: (null | object), requestHeaders: any): Promise<T> {
 
-        return this.client.request<void, T>({
+        const url = this.buildRequestUrl(path, queryParameters);
+        const timeout = this.getRequestTimeoutInMilliseconds();
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), timeout);
+
+        const fetchOptions: RequestInit = {
             method,
-            url: path,
-            data: body,
             headers: requestHeaders,
-            params: queryParameters,
-        }).catch((errorThrown: AxiosError) => {
-            return Promise.reject(this.transformError(errorThrown));
-        })
+            signal: controller.signal,
+        };
+
+        if (body !== null && body !== undefined) {
+            fetchOptions.body = JSON.stringify(body);
+        }
+
+        return fetch(url, fetchOptions)
+            .then((response: Response) => {
+                clearTimeout(timer);
+                return this.handleResponse<T>(response);
+            })
+            .catch((error: any) => {
+                clearTimeout(timer);
+                return Promise.reject(this.transformError(error));
+            });
     }
 
     /**
-     * Process callback function for HTTP request.
-     *
-     * @param error - request error that needs to be transformed to proper Postmark error.
-     *
-     * @return {PostmarkError} - formatted Postmark error
+     * Handle the fetch Response, parsing JSON and handling non-2xx status codes.
      */
-    private transformError(errorThrown:AxiosError): PostmarkError {
-        const response: AxiosResponse | undefined = errorThrown.response;
+    private handleResponse<T>(response: Response): Promise<T> {
+        return response.text().then((text: string) => {
+            let data: any;
+            try {
+                data = text ? JSON.parse(text) : {};
+            } catch (e) {
+                data = {};
+            }
 
-        if (response !== undefined) {
-            const status = this.adjustValue<number>(0, response.status);
-            const errorCode = this.adjustValue<number>(0, response.data.ErrorCode);
-            const message = this.adjustValue<string>(errorThrown.message, response.data.Message);
+            if (response.ok) {
+                return data as T;
+            }
 
-            return this.errorHandler.buildError(message, errorCode, status);
-        } else if (errorThrown.message !== undefined) {
-            return this.errorHandler.buildError(errorThrown.message);
-        }
-        else {
-            return this.errorHandler.buildError(JSON.stringify(errorThrown, Object.getOwnPropertyNames(errorThrown)));
-        }
+            // Non-2xx: build a proper error from the response body
+            const status = response.status || 0;
+            const errorCode = (data && data.ErrorCode) ? data.ErrorCode : 0;
+            const message = (data && data.Message) ? data.Message : response.statusText || "Unknown error";
+
+            return Promise.reject(this.errorHandler.buildError(message, errorCode, status));
+        });
     }
 
     /**
-     * Timeout in seconds is adjusted to Axios format.
+     * Transform a fetch error (network error, abort, etc.) into a PostmarkError.
+     *
+     * @param error - the error thrown during the fetch call
+     * @returns {PostmarkError} - formatted Postmark error
+     */
+    private transformError(error: any): PostmarkError {
+        // If it's already a PostmarkError (from handleResponse rejection), pass through
+        if (error instanceof PostmarkError) {
+            return error;
+        }
+
+        if (error && error.name === "AbortError") {
+            return this.errorHandler.buildError("Request timed out");
+        }
+
+        if (error && error.message !== undefined) {
+            return this.errorHandler.buildError(error.message);
+        }
+
+        return this.errorHandler.buildError(JSON.stringify(error, Object.getOwnPropertyNames(error)));
+    }
+
+    /**
+     * Build the full request URL with query parameters.
+     */
+    private buildRequestUrl(path: string, queryParameters: object): string {
+        const baseUrl = this.getBaseHttpRequestURL();
+        const url = `${baseUrl}${path}`;
+
+        const params = this.buildQueryString(queryParameters);
+        return params ? `${url}?${params}` : url;
+    }
+
+    /**
+     * Build a query string from an object of parameters.
+     * Filters out undefined and null values.
+     */
+    private buildQueryString(queryParameters: object): string {
+        const params = new URLSearchParams();
+
+        Object.keys(queryParameters).forEach((key) => {
+            const value = (queryParameters as any)[key];
+            if (value !== undefined && value !== null) {
+                params.append(key, String(value));
+            }
+        });
+
+        const result = params.toString();
+        return result;
+    }
+
+    /**
+     * Timeout in seconds is adjusted to milliseconds.
      *
      * @private
      */
     private getRequestTimeoutInMilliseconds(): number {
         return (this.clientOptions.timeout || 60) * 1000;
-    }
-
-    private adjustValue<T>(defaultValue: T, data: T): T {
-        return (data === undefined) ? defaultValue : data;
     }
 }

--- a/test/unit/AccountClient.test.ts
+++ b/test/unit/AccountClient.test.ts
@@ -34,7 +34,7 @@ describe("AccountClient", () => {
         });
 
         it("httpClient initialized", () => {
-            expect(client.httpClient.client.defaults).not.to.eql(180000);
+            expect(client.httpClient.client).not.to.equal(undefined);
         });
     });
 

--- a/test/unit/FetchHttpClient.test.ts
+++ b/test/unit/FetchHttpClient.test.ts
@@ -1,13 +1,13 @@
 import {expect} from "chai";
 import "mocha";
 import * as sinon from "sinon";
-import {AxiosHttpClient} from "../../src/client/HttpClient";
+import {FetchHttpClient} from "../../src/client/HttpClient";
 import {ClientOptions} from "../../src/client/models";
 import {Errors} from "../../src";
 
-describe("AxiosHttpClient", () => {
+describe("FetchHttpClient", () => {
     let sandbox: sinon.SinonSandbox;
-    const httpClient = new AxiosHttpClient();
+    const httpClient = new FetchHttpClient();
 
     beforeEach(() => {
         sandbox = sinon.createSandbox();
@@ -17,8 +17,22 @@ describe("AxiosHttpClient", () => {
         sandbox.restore();
     });
 
+    function stubFetchReject(error: any) {
+        sandbox.stub(global, "fetch").rejects(error);
+    }
+
+    function stubFetchResponse(status: number, body: any, ok?: boolean) {
+        const response = {
+            ok: ok !== undefined ? ok : (status >= 200 && status < 300),
+            status,
+            statusText: "Error",
+            text: () => Promise.resolve(JSON.stringify(body)),
+        };
+        sandbox.stub(global, "fetch").resolves(response as any);
+    }
+
     it("default error", () => {
-        sandbox.stub(httpClient.client, "request").rejects(new Error("test"));
+        stubFetchReject(new Error("test"));
 
         return httpClient.httpRequest(ClientOptions.HttpMethod.GET, "", {}, null, {}).then((result) => {
             throw Error(`Should not be here with result: ${result}`);
@@ -33,7 +47,7 @@ describe("AxiosHttpClient", () => {
 
     it("error with no message in it", () => {
         const errorToThrow: any = { stack: 'Hello stack' };
-        sandbox.stub(httpClient.client, "request").rejects(errorToThrow);
+        stubFetchReject(errorToThrow);
 
         return httpClient.httpRequest(ClientOptions.HttpMethod.GET, "", {}, null, {}).then((result) => {
             throw Error(`Should not be here with result: ${result}`);
@@ -45,12 +59,12 @@ describe("AxiosHttpClient", () => {
     });
 
     describe("http status code errors", () => {
-        const buildAxiosFormatError = (statusNumber: number) => ({
-            response: { data: { Message: "Basic error", ErrorCode: 0 }, status: statusNumber }
+        const buildErrorResponse = (statusNumber: number, errorCode?: number) => ({
+            Message: "Basic error", ErrorCode: errorCode !== undefined ? errorCode : 0
         });
 
         it("401", () => {
-            sandbox.stub(httpClient.client, "request").rejects(buildAxiosFormatError(401));
+            stubFetchResponse(401, buildErrorResponse(401));
 
             return httpClient.httpRequest(ClientOptions.HttpMethod.GET, "", {}, null, {}).then((result) => {
                 throw Error(`Should not be here with result: ${result}`);
@@ -60,7 +74,7 @@ describe("AxiosHttpClient", () => {
         });
 
         it("404", () => {
-            sandbox.stub(httpClient.client, "request").rejects(buildAxiosFormatError(404));
+            stubFetchResponse(404, buildErrorResponse(404));
 
             return httpClient.httpRequest(ClientOptions.HttpMethod.GET, "", {}, null, {}).then((result) => {
                 throw Error(`Should not be here with result: ${result}`);
@@ -70,7 +84,7 @@ describe("AxiosHttpClient", () => {
         });
 
         it("422", () => {
-            sandbox.stub(httpClient.client, "request").rejects(buildAxiosFormatError(422));
+            stubFetchResponse(422, buildErrorResponse(422));
 
             return httpClient.httpRequest(ClientOptions.HttpMethod.GET, "", {}, null, {}).then((result) => {
                 throw Error(`Should not be here with result: ${result}`);
@@ -80,9 +94,7 @@ describe("AxiosHttpClient", () => {
         });
 
         it("422 - inactive recipients", () => {
-            const errorToThrow = buildAxiosFormatError(422)
-            errorToThrow.response.data.ErrorCode=300
-            sandbox.stub(httpClient.client, "request").rejects(errorToThrow);
+            stubFetchResponse(422, buildErrorResponse(422, 300));
 
             return httpClient.httpRequest(ClientOptions.HttpMethod.GET, "", {}, null, {}).then((result) => {
                 throw Error(`Should not be here with result: ${result}`);
@@ -92,9 +104,7 @@ describe("AxiosHttpClient", () => {
         });
 
         it("422 - invalid email", () => {
-            const errorToThrow = buildAxiosFormatError(422)
-            errorToThrow.response.data.ErrorCode=406
-            sandbox.stub(httpClient.client, "request").rejects(errorToThrow);
+            stubFetchResponse(422, buildErrorResponse(422, 406));
 
             return httpClient.httpRequest(ClientOptions.HttpMethod.GET, "", {}, null, {}).then((result) => {
                 throw Error(`Should not be here with result: ${result}`);
@@ -104,8 +114,7 @@ describe("AxiosHttpClient", () => {
         });
 
         it("429", () => {
-            const errorToThrow = buildAxiosFormatError(429)
-            sandbox.stub(httpClient.client, "request").rejects(errorToThrow);
+            stubFetchResponse(429, buildErrorResponse(429));
 
             return httpClient.httpRequest(ClientOptions.HttpMethod.GET, "", {}, null, {}).then((result) => {
                 throw Error(`Should not be here with result: ${result}`);
@@ -115,8 +124,7 @@ describe("AxiosHttpClient", () => {
         });
 
         it("500", () => {
-            const errorToThrow = buildAxiosFormatError(500)
-            sandbox.stub(httpClient.client, "request").rejects(errorToThrow);
+            stubFetchResponse(500, buildErrorResponse(500));
 
             return httpClient.httpRequest(ClientOptions.HttpMethod.GET, "", {}, null, {}).then((result) => {
                 throw Error(`Should not be here with result: ${result}`);
@@ -126,8 +134,7 @@ describe("AxiosHttpClient", () => {
         });
 
         it("503", () => {
-            const errorToThrow = buildAxiosFormatError(500)
-            sandbox.stub(httpClient.client, "request").rejects(errorToThrow);
+            stubFetchResponse(500, buildErrorResponse(500));
 
             return httpClient.httpRequest(ClientOptions.HttpMethod.GET, "", {}, null, {}).then((result) => {
                 throw Error(`Should not be here with result: ${result}`);
@@ -137,8 +144,7 @@ describe("AxiosHttpClient", () => {
         });
 
         it("unknown status", () => {
-            const errorToThrow = buildAxiosFormatError(-1)
-            sandbox.stub(httpClient.client, "request").rejects(errorToThrow);
+            stubFetchResponse(-1, buildErrorResponse(-1), false);
 
             return httpClient.httpRequest(ClientOptions.HttpMethod.GET, "", {}, null, {}).then((result) => {
                 throw Error(`Should not be here with result: ${result}`);

--- a/test/unit/ServerClient.test.ts
+++ b/test/unit/ServerClient.test.ts
@@ -30,7 +30,7 @@ describe("ServerClient", () => {
         });
 
         it("httpClient initialized", () => {
-            expect(client.httpClient.client.defaults).not.to.eql(180000);
+            expect(client.httpClient.client).not.to.equal(undefined);
         });
     });
 


### PR DESCRIPTION
## Summary
Replaces axios with the native fetch API, eliminating the only runtime dependency and resolving url.parse deprecation warnings (#173) that originated from axios's transitive dependency chain.

### Changes
- **src/client/HttpClient.ts**: Rewrote AxiosHttpClient → FetchHttpClient using native fetch with AbortController timeout, manual JSON parsing, and PostmarkError handling
- **src/client/BaseClient.ts**: Updated import
- **test/unit/FetchHttpClient.test.ts**: Rewrote tests to stub global.fetch instead of axios internals
- **test/unit/ServerClient.test.ts**: Updated client existence check
- **test/unit/AccountClient.test.ts**: Updated client existence check
- **package.json**: Removed axios dependency
- **package-lock.json**: Regenerated

### Key Behaviors Preserved
- JSON response auto-parsing (via response.text() + JSON.parse for empty body safety)
- Error status code mapping (401→InvalidAPIKeyError, 422→ApiInputError, etc.)
- Configurable timeout via AbortController
- Content-Type headers for POST/PUT/PATCH

Fixes #173
Related: #130 (fetch support for Deno/Bun/edge runtimes)