### PR TITLE
Pre-publish package.json hygiene: publishConfig + npm pkg fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
   ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "directories": {
     "lib": "./dist/index.js"
   },

--- a/package.json
+++ b/package.json
@@ -44,18 +44,18 @@
   },
   "scripts": {
     "check-lockfile": "node scripts/check-lockfile-registry.js",
-    "compile": "rm -r -f ./dist && node_modules/.bin/tsc",
-    "test": "node_modules/.bin/mocha --timeout 30000 --retries 1 -r ts-node/register test/**/*test.ts",
-    "unittest": "node_modules/.bin/mocha --timeout 30000 --retries 1 -r ts-node/register test/unit/**/*test.ts",
-    "watchtests": "node_modules/.bin/mocha --timeout 30000 --retries 1 -r ts-node/register -R list -w --recursive -G test/**/*test.ts",
+    "compile": "rm -r -f ./dist && tsc",
+    "test": "mocha --timeout 30000 --retries 1 -r ts-node/register test/**/*test.ts",
+    "unittest": "mocha --timeout 30000 --retries 1 -r ts-node/register test/unit/**/*test.ts",
+    "watchtests": "mocha --timeout 30000 --retries 1 -r ts-node/register -R list -w --recursive -G test/**/*test.ts",
     "lint": "npx eslint src --ext ts --ignore-pattern 'src/*test*'; exit 0",
     "lintfix": "npx eslint src --ext ts --fix --ignore-pattern 'src/test*.ts'; exit 0",
-    "compile-docs": "echo 'Generating docs...' && mkdir -p ./docs && rm -r ./docs && node_modules/.bin/typedoc --options typedoc.json && git add -A ./docs && echo 'Generated docs!'"
+    "compile-docs": "echo 'Generating docs...' && mkdir -p ./docs && rm -r ./docs && typedoc --options typedoc.json && git add -A ./docs && echo 'Generated docs!'"
   },
   "homepage": "http://ActiveCampaign.github.io/postmark.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ActiveCampaign/postmark.js.git"
+    "url": "git+https://github.com/ActiveCampaign/postmark.js.git"
   },
   "bugs": {
     "url": "https://github.com/ActiveCampaign/postmark.js/issues"


### PR DESCRIPTION
Pre-publish `package.json` cleanup surfaced during the 5.0.0 release.

## 1. Pin the publish registry
Adds `publishConfig.registry = https://registry.npmjs.org/` so `npm publish` always targets the
public registry regardless of a machine's global npm config (e.g. an internal mirror). Prevents
accidentally publishing this public package to an internal proxy and removes the need to pass
`--registry` on every publish.

## 2. Resolve `npm pkg fix` publish warnings
`npm publish` was auto-correcting the manifest and warning about it:
- removed the redundant `node_modules/.bin/` prefix from the `mocha`/`tsc`/`typedoc` script commands
  (npm adds `./node_modules/.bin` to `PATH` for run-scripts, so bare names resolve)
- normalized `repository.url` to the `git+https://` form

Verified: `npm run compile` and `npm run unittest` (71 passing) still work, and `npm pack --dry-run`
is now warning-free and ships the correct files (`dist/`, README, LICENSE, CHANGELOG, package.json).

No runtime or public-API impact — manifest/publish metadata only.