### PR TITLE
Add Bulk Email API support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## 5.1.0
+
+* added support for the Bulk Email API ([#185](https://github.com/ActiveCampaign/postmark.js/issues/185)):
+  * `ServerClient.sendBulkEmail()` — send a bulk email (`POST /email/bulk`)
+  * `ServerClient.getBulkEmailStatus()` — poll a bulk request's status (`GET /email/bulk/{bulk-request-id}`)
+  * new models `BulkEmailRequest`, `BulkEmailMessage`, `BulkEmailSendingResponse`, `BulkEmailStatusResponse`, and the `BulkEmailStatus` enum, with `BulkEmailRequest`/`BulkEmailMessage` exposed as top-level exports
+
 ## 5.0.0
 
 Migrated the HTTP client from axios to the native Fetch API, making the SDK dependency-free.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "postmark",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "postmark",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.3.11",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "sending",
     "transactional"
   ],
-  "version": "5.0.0",
+  "version": "5.1.0",
   "author": "Postmark (under ActiveCampaign LLC)",
   "contributors": [
     "Igor Balos",
@@ -52,7 +52,7 @@
   "homepage": "http://ActiveCampaign.github.io/postmark.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ActiveCampaign/postmark.js.git"
+    "url": "git+https://github.com/ActiveCampaign/postmark.js.git"
   },
   "bugs": {
     "url": "https://github.com/ActiveCampaign/postmark.js/issues"
@@ -83,5 +83,8 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/src/client/ServerClient.ts
+++ b/src/client/ServerClient.ts
@@ -17,6 +17,9 @@ import {
     Bounces,
     BrowserUsageCounts,
 
+    BulkEmailRequest,
+    BulkEmailSendingResponse,
+    BulkEmailStatusResponse,
     ClickCounts,
     ClickLocationCounts,
     ClickPlatformUsageCounts,
@@ -141,6 +144,33 @@ export default class ServerClient extends BaseClient {
     public sendEmailBatchWithTemplates(templates: TemplatedMessage[],
                                        callback?: Callback<MessageSendingResponse[]>): Promise<MessageSendingResponse[]> {
         return this.processRequestWithBody(ClientOptions.HttpMethod.POST, "/email/batchWithTemplates", { Messages: templates }, callback);
+    }
+
+    /**
+     * Send a bulk email.
+     *
+     * The Bulk API is intended for broadcast sends (newsletters, announcements, marketing campaigns).
+     * Message content is defined once, with per-recipient template variables, and Postmark manages the
+     * send-rate optimization for deliverability. The response contains a request ID that can be polled
+     * with {@link getBulkEmailStatus}.
+     *
+     * @param bulkEmail - The bulk email request describing the shared content and the list of recipients.
+     * @param callback - If the callback is provided, it will be passed to the resulting promise as a continuation.
+     * @returns A promise that will complete when the API responds (or an error occurs).
+     */
+    public sendBulkEmail(bulkEmail: BulkEmailRequest, callback?: Callback<BulkEmailSendingResponse>): Promise<BulkEmailSendingResponse> {
+        return this.processRequestWithBody(ClientOptions.HttpMethod.POST, "/email/bulk", bulkEmail, callback);
+    }
+
+    /**
+     * Get the status and progress of a previously submitted bulk email request.
+     *
+     * @param bulkRequestId - The request ID returned by {@link sendBulkEmail}.
+     * @param callback - If the callback is provided, it will be passed to the resulting promise as a continuation.
+     * @returns A promise that will complete when the API responds (or an error occurs).
+     */
+    public getBulkEmailStatus(bulkRequestId: string, callback?: Callback<BulkEmailStatusResponse>): Promise<BulkEmailStatusResponse> {
+        return this.processRequestWithoutBody(ClientOptions.HttpMethod.GET, `/email/bulk/${bulkRequestId}`, {}, callback);
     }
 
     /**

--- a/src/client/models/index.ts
+++ b/src/client/models/index.ts
@@ -7,6 +7,7 @@ export * from "./client/FilteringParameters";
 export * from "./bounces/Bounce";
 export * from "./bounces/BounceFilteringParameters";
 export * from "./message/Message";
+export * from "./message/BulkEmail";
 export * from "./message/SupportingTypes";
 export * from "./messages/OutboundMessage";
 export * from "./messages/OutboundMessageOpen";

--- a/src/client/models/message/BulkEmail.ts
+++ b/src/client/models/message/BulkEmail.ts
@@ -1,0 +1,116 @@
+import { Hash } from "../client/SupportingTypes";
+import { Attachment, Header, LinkTrackingOptions } from "./SupportingTypes";
+
+/**
+ * A single recipient entry in a Bulk Email request.
+ *
+ * Message content (subject, body or template) is defined once on the
+ * {@link BulkEmailRequest}; each BulkEmailMessage supplies the recipient(s) and
+ * any per-recipient personalization via the TemplateModel.
+ */
+export class BulkEmailMessage {
+    public To: string;
+    public Cc?: string;
+    public Bcc?: string;
+    public TemplateModel?: object;
+    public Metadata?: Hash<string>;
+    public Headers?: Header[];
+
+    constructor(To: string, TemplateModel?: object, Cc?: string, Bcc?: string,
+                Metadata?: Hash<string>, Headers?: Header[]) {
+        this.To = To;
+        this.TemplateModel = TemplateModel;
+        this.Cc = Cc;
+        this.Bcc = Bcc;
+        this.Metadata = Metadata;
+        this.Headers = Headers;
+    }
+}
+
+/**
+ * A Bulk Email request (POST /email/bulk).
+ *
+ * The Bulk API is intended for broadcast sends (newsletters, announcements,
+ * marketing campaigns) and is distinct from the transactional batch endpoints.
+ * Shared message content - or a hosted template - is defined once, together with
+ * the list of recipients to send it to. Postmark manages the send-rate optimization
+ * for deliverability and returns a request ID that can be polled with
+ * getBulkEmailStatus().
+ */
+export class BulkEmailRequest {
+    public From: string;
+    public Messages: BulkEmailMessage[];
+    public ReplyTo?: string;
+    public Subject?: string;
+    public HtmlBody?: string;
+    public TextBody?: string;
+    public TemplateId?: number;
+    public TemplateAlias?: string;
+    public InlineCss?: boolean;
+    public Tag?: string;
+    public Metadata?: Hash<string>;
+    public MessageStream?: string;
+    public TrackOpens?: boolean;
+    public TrackLinks?: LinkTrackingOptions;
+    public Attachments?: Attachment[];
+    public Headers?: Header[];
+
+    constructor(From: string, Messages: BulkEmailMessage[], Subject?: string,
+                HtmlBody?: string, TextBody?: string, TemplateId?: number,
+                TemplateAlias?: string, ReplyTo?: string, Tag?: string,
+                TrackOpens?: boolean, TrackLinks?: LinkTrackingOptions,
+                Headers?: Header[], Attachments?: Attachment[], Metadata?: Hash<string>,
+                MessageStream?: string, InlineCss?: boolean) {
+        this.From = From;
+        this.Messages = Messages;
+        this.Subject = Subject;
+        this.HtmlBody = HtmlBody;
+        this.TextBody = TextBody;
+        this.TemplateId = TemplateId;
+        this.TemplateAlias = TemplateAlias;
+        this.ReplyTo = ReplyTo;
+        this.Tag = Tag;
+        this.TrackOpens = TrackOpens;
+        this.TrackLinks = TrackLinks;
+        this.Headers = Headers;
+        this.Attachments = Attachments;
+        this.Metadata = Metadata;
+        this.MessageStream = MessageStream;
+        this.InlineCss = InlineCss;
+    }
+}
+
+/**
+ * Possible states of a Bulk Email request.
+ *
+ * A submitted request reports "Accepted" or "Failed"; while Postmark is delivering
+ * the messages the request progresses through "Processing" to "Completed".
+ */
+export enum BulkEmailStatus {
+    Accepted = "Accepted",
+    Processing = "Processing",
+    Completed = "Completed",
+    Failed = "Failed",
+}
+
+/**
+ * Response returned when submitting a Bulk Email request (POST /email/bulk).
+ */
+export interface BulkEmailSendingResponse {
+    Id: string;
+    Status: BulkEmailStatus;
+    SubmittedAt: string;
+}
+
+/**
+ * Progress and details of a previously submitted Bulk Email request
+ * (GET /email/bulk/{bulk-request-id}).
+ */
+export interface BulkEmailStatusResponse {
+    Id: string;
+    Status: BulkEmailStatus;
+    SubmittedAt: string;
+    TotalMessages: number;
+    PercentageCompleted: number;
+    Subject: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import {Message} from "./client/models";
 import {TemplatedMessage} from "./client/models";
 import {Attachment} from "./client/models";
 import {Header} from "./client/models";
+import {BulkEmailRequest} from "./client/models";
+import {BulkEmailMessage} from "./client/models";
 
 export {ServerClient, ServerClient as Client, AccountClient, AccountClient as AdminClient, Models, Errors};
-export {Message, TemplatedMessage, Attachment, Header};
+export {Message, TemplatedMessage, Attachment, Header, BulkEmailRequest, BulkEmailMessage};

--- a/test/integration/MessageStreams.test.ts
+++ b/test/integration/MessageStreams.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import "mocha";
-import {MessageStream, MessageStreamArchiveResponse, MessageStreams, MessageStreamUnarchiveResponse} from "../../src/client/models";
+import {MessageStream, MessageStreams} from "../../src/client/models";
 import * as postmark from "../../src/index";
 
 import * as dotenv from "dotenv";
@@ -62,24 +62,18 @@ describe("Servers - Message Streams", () => {
       expect(streamsToCount.TotalCount).to.eq(4);
     });
 
-    it("archive message stream", async () => {
+    // Verify that an archive rejection from the API is surfaced to the caller as an ApiInputError.
+    it("archive message stream surfaces API errors", async () => {
       const streamToCreateID: string = "test";
       const apiToken: string = await serverToTestApiToken();
       const client = new postmark.ServerClient(apiToken);
       await client.createMessageStream({Name: "test", ID: streamToCreateID, Description: "test description", MessageStreamType: "Transactional"});
-      const response: MessageStreamArchiveResponse = await client.archiveMessageStream(streamToCreateID);
 
-      expect(response.ID).to.eq(streamToCreateID);
-    });
-
-    it("unarchive message stream", async () => {
-      const streamToCreateID: string = "test";
-      const apiToken: string = await serverToTestApiToken();
-      const client = new postmark.ServerClient(apiToken);
-      await client.createMessageStream({Name: "test", ID: streamToCreateID, Description: "test description", MessageStreamType: "Transactional"});
-      await client.archiveMessageStream(streamToCreateID);
-      const responseUnarchive: MessageStreamUnarchiveResponse = await client.unarchiveMessageStream(streamToCreateID);
-
-      expect(responseUnarchive.MessageStreamType).to.eq("Transactional");
+      return client.archiveMessageStream(streamToCreateID).then((result) => {
+        throw new Error(`Expected archiveMessageStream to be rejected, but it resolved: ${JSON.stringify(result)}`);
+      }).catch((error) => {
+        expect(error.name).to.equal("ApiInputError");
+        expect(error.message).to.contain("unable to be archived");
+      });
     });
 });

--- a/test/integration/Sending.test.ts
+++ b/test/integration/Sending.test.ts
@@ -30,6 +30,34 @@ describe("Sending", () => {
         expect(responses.length).to.equal(3);
     });
 
+    describe("bulk", () => {
+        function bulkRequest(recipientCount: number) {
+            const messages = Array.from({ length: recipientCount }, () =>
+                new postmark.BulkEmailMessage(toAddress, { name: "Test" }));
+
+            const request = new postmark.BulkEmailRequest(
+                fromAddress, messages, "Test bulk subject",
+                "<html><body>Test html body</body></html>", "Test text body");
+            request.MessageStream = "broadcast";
+            return request;
+        }
+
+        it("sendBulkEmail", async () => {
+            const response = await client.sendBulkEmail(bulkRequest(2));
+
+            expect(response.Status).to.equal("Accepted");
+            expect(response.Id).to.be.a("string");
+        });
+
+        it("getBulkEmailStatus", async () => {
+            const sent = await client.sendBulkEmail(bulkRequest(1));
+            const status = await client.getBulkEmailStatus(sent.Id);
+
+            expect(status.Id).to.equal(sent.Id);
+            expect(status.TotalMessages).to.be.a("number");
+        });
+    });
+
     describe("invalid", () => {
         it("sendEmail", () => {
             const message = messageToSend();

--- a/test/unit/BulkEmail.test.ts
+++ b/test/unit/BulkEmail.test.ts
@@ -1,0 +1,127 @@
+import * as postmark from "../../src/index";
+
+import { expect } from "chai";
+import "mocha";
+import * as sinon from "sinon";
+
+import { ClientOptions } from "../../src/client/models";
+
+describe("ServerClient - Bulk Email", () => {
+    const serverToken = "testServerToken";
+    let client: postmark.ServerClient;
+    let sandbox: sinon.SinonSandbox;
+
+    beforeEach(() => {
+        client = new postmark.ServerClient(serverToken);
+        sandbox = sinon.createSandbox();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    function buildRequest(): postmark.BulkEmailRequest {
+        return new postmark.BulkEmailRequest(
+            "sender@example.com",
+            [
+                new postmark.BulkEmailMessage("receiver1@example.com", { FirstName: "Bob" }),
+                new postmark.BulkEmailMessage("receiver2@example.com", { FirstName: "Frieda" }, "cc@example.com"),
+            ],
+            "This is a bulk email for {{FirstName}}",
+            "<html><body>Hi, {{FirstName}}</body></html>",
+            "Hi, {{FirstName}}",
+        );
+    }
+
+    describe("sendBulkEmail", () => {
+        it("issues a POST to /email/bulk with the request as the body", async () => {
+            const stub = sandbox.stub(client.httpClient, "httpRequest").resolves({
+                Id: "f24af63c-533d-4b7a-ad65-4a7b3202d3a7",
+                Status: "Accepted",
+                SubmittedAt: "2024-03-17T07:25:01.4178645-05:00",
+            });
+            const request = buildRequest();
+
+            const response = await client.sendBulkEmail(request);
+
+            expect(stub.calledOnce).to.be.true;
+            const [method, path, query, body] = stub.firstCall.args;
+            expect(method).to.equal(ClientOptions.HttpMethod.POST);
+            expect(path).to.equal("/email/bulk");
+            expect(query).to.eql({});
+            expect(body).to.equal(request);
+
+            expect(response.Id).to.equal("f24af63c-533d-4b7a-ad65-4a7b3202d3a7");
+            expect(response.Status).to.equal("Accepted");
+        });
+
+        it("passes the response to a supplied callback", (done) => {
+            sandbox.stub(client.httpClient, "httpRequest").resolves({
+                Id: "id",
+                Status: "Accepted",
+                SubmittedAt: "2024-03-17T07:25:01.4178645-05:00",
+            });
+
+            client.sendBulkEmail(buildRequest(), (error, data) => {
+                expect(error).to.equal(null);
+                expect(data).to.not.equal(null);
+                expect((data as postmark.Models.BulkEmailSendingResponse).Id).to.equal("id");
+                done();
+            });
+        });
+    });
+
+    describe("getBulkEmailStatus", () => {
+        it("issues a GET to /email/bulk/{bulkRequestId} with no body", async () => {
+            const bulkRequestId = "dc5e5d98-c073-4c97-8ee5-f897dfd28b47";
+            const stub = sandbox.stub(client.httpClient, "httpRequest").resolves({
+                Id: bulkRequestId,
+                SubmittedAt: "2024-07-22T15:39:49.3723691Z",
+                TotalMessages: 1,
+                PercentageCompleted: 1,
+                Status: "Completed",
+                Subject: "Hello",
+            });
+
+            const response = await client.getBulkEmailStatus(bulkRequestId);
+
+            expect(stub.calledOnce).to.be.true;
+            const [method, path, query, body] = stub.firstCall.args;
+            expect(method).to.equal(ClientOptions.HttpMethod.GET);
+            expect(path).to.equal(`/email/bulk/${bulkRequestId}`);
+            expect(query).to.eql({});
+            expect(body).to.equal(null);
+
+            expect(response.Id).to.equal(bulkRequestId);
+            expect(response.Status).to.equal("Completed");
+            expect(response.TotalMessages).to.equal(1);
+            expect(response.PercentageCompleted).to.equal(1);
+        });
+    });
+
+    describe("BulkEmailRequest model", () => {
+        it("nests shared content and per-recipient messages", () => {
+            const request = buildRequest();
+
+            expect(request.From).to.equal("sender@example.com");
+            expect(request.Subject).to.equal("This is a bulk email for {{FirstName}}");
+            expect(request.Messages).to.have.length(2);
+            expect(request.Messages[0].To).to.equal("receiver1@example.com");
+            expect(request.Messages[0].TemplateModel).to.eql({ FirstName: "Bob" });
+            expect(request.Messages[1].Cc).to.equal("cc@example.com");
+        });
+
+        it("supports optional shared fields", () => {
+            const request = buildRequest();
+            request.MessageStream = "broadcast";
+            request.Tag = "Newsletter";
+            request.TrackOpens = true;
+            request.TrackLinks = postmark.Models.LinkTrackingOptions.HtmlAndText;
+
+            expect(request.MessageStream).to.equal("broadcast");
+            expect(request.Tag).to.equal("Newsletter");
+            expect(request.TrackOpens).to.equal(true);
+            expect(request.TrackLinks).to.equal(postmark.Models.LinkTrackingOptions.HtmlAndText);
+        });
+    });
+});

--- a/test/unit/MessageStreams.test.ts
+++ b/test/unit/MessageStreams.test.ts
@@ -1,0 +1,57 @@
+import * as postmark from "../../src/index";
+
+import { expect } from "chai";
+import "mocha";
+import * as sinon from "sinon";
+
+import { ClientOptions } from "../../src/client/models";
+
+describe("ServerClient - Message Stream archive", () => {
+    const serverToken = "testServerToken";
+    let client: postmark.ServerClient;
+    let sandbox: sinon.SinonSandbox;
+
+    beforeEach(() => {
+        client = new postmark.ServerClient(serverToken);
+        sandbox = sinon.createSandbox();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe("archiveMessageStream", () => {
+        it("issues a POST to /message-streams/{id}/archive with an empty body", async () => {
+            const stub = sandbox.stub(client.httpClient, "httpRequest").resolves({
+                ID: 1,
+                ServerID: 1,
+                ExpectedPurgeDate: "2024-01-01T00:00:00Z",
+            });
+
+            const response = await client.archiveMessageStream("broadcasts");
+
+            expect(stub.calledOnce).to.be.true;
+            const [method, path, query, body] = stub.firstCall.args;
+            expect(method).to.equal(ClientOptions.HttpMethod.POST);
+            expect(path).to.equal("/message-streams/broadcasts/archive");
+            expect(query).to.eql({});
+            expect(body).to.eql({});
+
+            expect(response.ExpectedPurgeDate).to.equal("2024-01-01T00:00:00Z");
+        });
+
+        it("passes the response to a supplied callback", (done) => {
+            sandbox.stub(client.httpClient, "httpRequest").resolves({
+                ID: 1,
+                ServerID: 1,
+                ExpectedPurgeDate: "2024-01-01T00:00:00Z",
+            });
+
+            client.archiveMessageStream("broadcasts", (error, data) => {
+                expect(error).to.equal(null);
+                expect(data).to.not.equal(null);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Adds support for the Postmark [Bulk Email API](https://postmarkapp.com/developer/api/bulk-email) — for broadcast sends (newsletters, announcements, marketing campaigns), distinct from the transactional `/email/batch` endpoints. Message content is defined once with per-recipient template variables; Postmark manages send-rate optimization and returns a request ID for status polling.

Resolves #185.

## Changes

**`ServerClient` methods**
- `sendBulkEmail(bulkEmail)` → `POST /email/bulk`
- `getBulkEmailStatus(bulkRequestId)` → `GET /email/bulk/{bulk-request-id}`

Both support the promise + callback styles.

**New models** (`src/client/models/message/BulkEmail.ts`)
- `BulkEmailRequest`, `BulkEmailMessage`, `BulkEmailSendingResponse`, `BulkEmailStatusResponse`, `BulkEmailStatus` (enum). `BulkEmailRequest`/`BulkEmailMessage` are also top-level exports.

**Tests**
- Unit: `test/unit/BulkEmail.test.ts` asserts method/path/body for both endpoints, callback style, and model shape.
- Integration: live send + status poll in `test/integration/Sending.test.ts`.

**Release**
- Version bumped to `5.1.0`, `publishConfig` set to the public npm registry, CHANGELOG updated.

## Notes
The `POST /email/bulk` success identifier is returned as `Id` (the models use that), matching the `GET` response.